### PR TITLE
Adjust hackmode so it properly associates / gossips meta items with base addresses

### DIFF
--- a/packages/hackmode/lib/index.js
+++ b/packages/hackmode/lib/index.js
@@ -351,13 +351,11 @@ class N3hHackMode extends AsyncClass {
       if (hl.dnaAddress in this._memory) {
         const ref = this._memory[hl.dnaAddress].mem
         for (let hash of hl.hashList) {
-          if (!ref.has(hash)) {
-            this._p2p.send(fromId, {
-              type: 'getData',
-              dnaAddress: hl.dnaAddress,
-              hash
-            })
-          }
+          this._p2p.send(fromId, {
+            type: 'getData',
+            dnaAddress: hl.dnaAddress,
+            hash
+          })
         }
       }
     }
@@ -399,6 +397,7 @@ class N3hHackMode extends AsyncClass {
       const mem = new Mem()
       mem.registerIndexer((store, data) => {
         if (data && data.type === 'dht') {
+          log.t('got dht', data)
           this._ipc.send('json', {
             method: 'storeDht',
             _id: data._id,
@@ -411,7 +410,7 @@ class N3hHackMode extends AsyncClass {
       })
       mem.registerIndexer((store, data) => {
         if (data && data.type === 'dhtMeta') {
-          log.e('got dhtMeta', data)
+          log.t('got dhtMeta', data)
           this._ipc.send('json', {
             method: 'storeDhtMeta',
             _id: data._id,
@@ -428,6 +427,7 @@ class N3hHackMode extends AsyncClass {
         mem,
         agentToTransportId: mem.registerIndexer((store, data) => {
           if (data && data.type === 'agent') {
+            log.t('got peer', data)
             store[data.agentId] = data.transportId
             this._ipc.send('json', {
               method: 'peerConnected',

--- a/packages/hackmode/lib/index.js
+++ b/packages/hackmode/lib/index.js
@@ -349,7 +349,6 @@ class N3hHackMode extends AsyncClass {
 
     for (let hl of hashList) {
       if (hl.dnaAddress in this._memory) {
-        const ref = this._memory[hl.dnaAddress].mem
         for (let hash of hl.hashList) {
           this._p2p.send(fromId, {
             type: 'getData',

--- a/packages/hackmode/lib/mem.js
+++ b/packages/hackmode/lib/mem.js
@@ -79,6 +79,9 @@ class Mem {
   }
 
   insert (data) {
+    if (!data || typeof data.address !== 'string' || !data.address.length) {
+      throw new Error('cannot insert without string address')
+    }
     const entry = this._getEntry(data.address)
     const strData = JSON.stringify(data)
     if (entry.entry !== strData) {
@@ -91,6 +94,9 @@ class Mem {
   }
 
   insertMeta (data) {
+    if (!data || typeof data.address !== 'string' || !data.address.length) {
+      throw new Error('cannot insert without string address')
+    }
     const entry = this._getEntry(data.address)
     const strData = JSON.stringify(data)
     const hash = getHash(strData)

--- a/packages/hackmode/lib/mem.js
+++ b/packages/hackmode/lib/mem.js
@@ -1,35 +1,27 @@
 const crypto = require('crypto')
 
-const getLoc = exports.getLoc = function getLoc (hash) {
-  let loc = hash.readInt8(0)
-  for (let i = 1; i < 32; i += 1) {
-    loc = loc ^ hash.readInt8(i)
+// bit of a hack, treat the address as utf8,
+// then xor into a single byte
+const getLoc = exports.getLoc = function getLoc (address) {
+  const buf = Buffer.from(address, 'utf8')
+  let loc = buf.readInt8(0)
+  for (let i = 1; i < buf.byteLength; ++i) {
+    loc = loc ^ buf.readInt8(i)
   }
-  const b = Buffer.alloc(1)
-  b.writeInt8(loc, 0)
-  return b.toString('hex')
+  return loc.toString(16)
 }
 
-const getHash = exports.getHash = function getHash (buffer) {
+const getHash = exports.getHash = function getHash (str) {
   const hasher = crypto.createHash('sha256')
-  hasher.update(buffer)
-  return hasher.digest()
-}
-
-const getEntry = exports.getEntry = function getEntry (data) {
-  const buffer = Buffer.from(JSON.stringify(data), 'utf8')
-  const hash = getHash(buffer)
-  return {
-    loc: getLoc(hash),
-    hash: hash.toString('base64'),
-    buffer
-  }
+  hasher.update(Buffer.from(str, 'utf8'))
+  return hasher.digest().toString('base64')
 }
 
 class Mem {
   constructor () {
-    this._data = {}
+    this._data = new Map()
     this._indexers = []
+    this._locHashes = {}
   }
 
   registerIndexer (fn) {
@@ -38,70 +30,129 @@ class Mem {
     return store
   }
 
-  insert (data) {
-    const entry = getEntry(data)
-    if (!(entry.loc in this._data)) {
-      this._data[entry.loc] = {}
+  /**
+   * we need a way to generate consistent hashes
+   * (that is, work around insertion order)
+   */
+  _genLocHashes () {
+    this._locHashes = {}
+    for (let [loc, sub] of this._data) {
+      const locData = []
+
+      const addrs = Array.from(sub.keys()).sort()
+      for (let addr of addrs) {
+        const entry = sub.get(addr)
+        const meta = []
+
+        const metaHashes = Array.from(entry.meta.keys()).sort()
+        for (let metaHash of metaHashes) {
+          const metaItem = entry.meta.get(metaHash)
+          meta.push([metaHash, metaItem])
+        }
+
+        locData.push([addr, entry.entry, meta])
+      }
+
+      this._locHashes[loc] = getHash(JSON.stringify(locData))
     }
-    if (entry.hash in this._data[entry.loc]) {
-      return false
-    }
-    this._data[entry.loc][entry.hash] = entry
-    for (let idx of this._indexers) {
-      idx[1](idx[0], entry.hash, data)
-    }
-    return true
   }
 
-  has (hash) {
-    const loc = getLoc(Buffer.from(hash, 'base64'))
-    if (!(loc in this._data)) {
-      return false
+  _getEntry (address) {
+    const loc = getLoc(address)
+    if (!this._data.has(loc)) {
+      this._data.set(loc, new Map())
     }
-    if (hash in this._data[loc]) {
+    const ref = this._data.get(loc)
+    if (!ref.has(address)) {
+      ref.set(address, {
+        entry: '{}',
+        meta: new Map()
+      })
+    }
+    return ref.get(address)
+  }
+
+  _publishIndex (data) {
+    for (let idx of this._indexers) {
+      idx[1](idx[0], data)
+    }
+  }
+
+  insert (data) {
+    const entry = this._getEntry(data.address)
+    const strData = JSON.stringify(data)
+    if (entry.entry !== strData) {
+      entry.entry = strData
+      this._genLocHashes()
+      this._publishIndex(data)
       return true
     }
     return false
   }
 
-  get (hash) {
-    const loc = getLoc(Buffer.from(hash, 'base64'))
-    if (!(loc in this._data)) {
+  insertMeta (data) {
+    const entry = this._getEntry(data.address)
+    const strData = JSON.stringify(data)
+    const hash = getHash(strData)
+    if (!entry.meta.has(hash)) {
+      entry.meta.set(hash, strData)
+      this._genLocHashes()
+      this._publishIndex(data)
+      return true
+    }
+    return false
+  }
+
+  has (address) {
+    const loc = getLoc(address)
+    if (!this._data.has(loc)) {
+      return false
+    }
+    const ref = this._data.get(loc)
+    if (ref.has(address)) {
+      return true
+    }
+    return false
+  }
+
+  get (address) {
+    const loc = getLoc(address)
+    if (!this._data.has(loc)) {
       return
     }
-    if (hash in this._data[loc]) {
-      return JSON.parse(this._data[loc][hash].buffer.toString('utf8'))
+    const ref = this._data.get(loc)
+    if (ref.has(address)) {
+      const entry = ref.get(address)
+      const out = {
+        entry: JSON.parse(entry.entry),
+        meta: []
+      }
+      for (let metaItem of entry.meta.values()) {
+        out.meta.push(JSON.parse(metaItem))
+      }
+      return out
     }
   }
 
   toJSON () {
     const out = {}
-    for (let loc in this._data) {
-      for (let hash in this._data[loc]) {
-        out[hash] = JSON.parse(this._data[loc][hash].buffer.toString('utf8'))
+    for (let sub of this._data.values()) {
+      for (let addr of sub.keys()) {
+        out[addr] = this.get(addr)
       }
     }
     return out
   }
 
-  getHashHashForLoc (loc) {
-    return getHash(Buffer.concat(Object.keys(this._data[loc]).map(
-      h => Buffer.from(h, 'base64')))).toString('base64')
-  }
-
   getGossipHashHash () {
-    const out = {}
-    for (let loc in this._data) {
-      out[loc] = this.getHashHashForLoc(loc)
-    }
-    return out
+    return JSON.parse(JSON.stringify(this._locHashes))
   }
 
   getGossipLocListForGossipHashHash (gossipHashHash) {
     const out = []
     for (let loc in gossipHashHash) {
-      if (loc in this._data) {
-        if (gossipHashHash[loc] !== this.getHashHashForLoc(loc)) {
+      if (loc in this._locHashes) {
+        if (gossipHashHash[loc] !== this._locHashes[loc]) {
           out.push(loc)
         }
       } else {
@@ -114,9 +165,9 @@ class Mem {
   getGossipHashesForGossipLocList (gossipLocList) {
     const out = []
     for (let loc of gossipLocList) {
-      if (loc in this._data) {
-        for (let hash in this._data[loc]) {
-          out.push(hash)
+      if (this._data.has(loc)) {
+        for (let addr of this._data.get(loc).keys()) {
+          out.push(addr)
         }
       }
     }

--- a/packages/hackmode/lib/mem.test.js
+++ b/packages/hackmode/lib/mem.test.js
@@ -8,10 +8,10 @@ describe('HackMode Mem Suite', () => {
   beforeEach(() => {
     m = new Mem()
     m.insert({
-      v: 'test1'
+      address: 'test1'
     })
     m.insert({
-      v: 'test2'
+      address: 'test2'
     })
   })
 
@@ -20,19 +20,22 @@ describe('HackMode Mem Suite', () => {
   })
 
   it('should json', () => {
-    expect(JSON.stringify(m)).equals('{"OYAEmbRpxTognzO4iFhiaytimxCxgw43Wdj1AJ4XYJo=":{"v":"test1"},"Nmu2RpmSXt5X5J9DlgV76scoEayztSXYHoRmcjlki+k=":{"v":"test2"}}')
+    expect(JSON.stringify(m)).equals('{"test1":{"entry":{"address":"test1"},"meta":[]},"test2":{"entry":{"address":"test2"},"meta":[]}}')
   })
 
   it('should get', () => {
-    expect(m.get('OYAEmbRpxTognzO4iFhiaytimxCxgw43Wdj1AJ4XYJo=')).deep.equals({
-      v: 'test1'
+    expect(m.get('test1')).deep.equals({
+      entry: {
+        address: 'test1'
+      },
+      meta: []
     })
   })
 
   it('should gossip hash hash', () => {
     expect(m.getGossipHashHash()).deep.equals({
-      '25': 'AauR62PJpQO/h3s/VsE9EywS2QfpGTs9lMk5G5T3qsY=',
-      '53': '1FAPsc4wYjNuokxtnJUlnmk55otWF6Dc1UM7suTf64Q='
+      '24': 'I8XwOtgtojmOKzo7qJwSetie154IwJnxJV0HMiVjEY0=',
+      '27': 'CNs5L9IOXSl6+PrJ2DXGLJQgMc/yyuyE4Fj4FTkgxQ4='
     })
   })
 
@@ -57,7 +60,7 @@ describe('HackMode Mem Suite', () => {
     hh[loc] = 'fake'
     const res = m.getGossipHashesForGossipLocList(m.getGossipLocListForGossipHashHash(hh))
     expect(res).deep.equals([
-      'OYAEmbRpxTognzO4iFhiaytimxCxgw43Wdj1AJ4XYJo='
+      'test2'
     ])
   })
 })

--- a/packages/n3h-ipc/lib/server.js
+++ b/packages/n3h-ipc/lib/server.js
@@ -82,7 +82,7 @@ class IpcServer extends AsyncClass {
 
   sendOne (zmqid, name, data) {
     this.$checkDestroyed()
-      this._send(zmqid, name, data)
+    this._send(zmqid, name, data)
   }
 
   // -- private -- //

--- a/packages/n3h-mock/lib/index.js
+++ b/packages/n3h-mock/lib/index.js
@@ -13,7 +13,6 @@ tweetlog.set('t')
 const log = tweetlog('@mock@')
 
 class N3hMock extends AsyncClass {
-
   /// Network mock init.
   /// Normally spawned by holochain_net where config is passed via environment variables
   async init () {
@@ -85,7 +84,6 @@ class N3hMock extends AsyncClass {
 
   // Received 'message' from IPC: process it
   _handleIpcMessage (opt) {
-
     if (opt.name === 'ping') {
       return
     }

--- a/packages/n3h-mock/lib/mem.test.js
+++ b/packages/n3h-mock/lib/mem.test.js
@@ -24,5 +24,4 @@ describe('Mock Mem Suite', () => {
       v: 'test1'
     })
   })
-
 })


### PR DESCRIPTION
Need to track meta items along with base addresses.
Alters the gossip workflow such that the any change to the aggregation of base entry and all associated meta items will cause a sync.