### PR TITLE
Tweetlog API docs && file logging for n3h

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -24,3 +24,7 @@
 - [client](n3h-ipc/client.md)
 - [server](n3h-ipc/server.md)
 
+### tweetlog
+
+- [tweetlog](tweetlog/tweetlog.md)
+

--- a/docs/tweetlog/tweetlog.md
+++ b/docs/tweetlog/tweetlog.md
@@ -1,0 +1,217 @@
+<a name="module_tweetlog"></a>
+
+## tweetlog ⇒ <code>Logger</code>
+A bare-bones logging helper for light-weight javascript logging.
+This module itself is a function that returns a logger instance
+when given a tag.
+
+tweetlog (without api comments / tests) currently fits into 5 tweets.
+Homage to https://tweetnacl.cr.yp.to/
+
+
+| Param | Type | Description |
+| --- | --- | --- |
+| tag | <code>string</code> | a logging tag to mark messages |
+
+**Example**  
+```js
+const tweetlog = require('tweetlog')
+tweetlog.listen(tweetlog.console)
+const log = tweetlog('my-log')
+log.e('circumstance a', new Error('something bad'))
+```
+
+* [tweetlog](#module_tweetlog) ⇒ <code>Logger</code>
+    * _static_
+        * [.Logger](#module_tweetlog.Logger) : <code>object</code>
+            * [.tag](#module_tweetlog.Logger+tag)
+            * [.t(...args)](#module_tweetlog.Logger+t)
+            * [.d(...args)](#module_tweetlog.Logger+d)
+            * [.i(...args)](#module_tweetlog.Logger+i)
+            * [.w(...args)](#module_tweetlog.Logger+w)
+            * [.e(...args)](#module_tweetlog.Logger+e)
+    * _inner_
+        * [~console(level, tag, ...args)](#module_tweetlog..console)
+        * [~set(level, [tag])](#module_tweetlog..set)
+        * [~listen(listener)](#module_tweetlog..listen)
+        * [~unlisten(listener)](#module_tweetlog..unlisten)
+        * [~unlistenAll()](#module_tweetlog..unlistenAll)
+        * [~resetLevels()](#module_tweetlog..resetLevels)
+        * [~gte(a, b)](#module_tweetlog..gte) ⇒ <code>boolean</code>
+        * [~should(level, [tag])](#module_tweetlog..should)
+
+<a name="module_tweetlog.Logger"></a>
+
+### tweetlog.Logger : <code>object</code>
+A tagged logger instance
+
+**Kind**: static namespace of [<code>tweetlog</code>](#module_tweetlog)  
+
+* [.Logger](#module_tweetlog.Logger) : <code>object</code>
+    * [.tag](#module_tweetlog.Logger+tag)
+    * [.t(...args)](#module_tweetlog.Logger+t)
+    * [.d(...args)](#module_tweetlog.Logger+d)
+    * [.i(...args)](#module_tweetlog.Logger+i)
+    * [.w(...args)](#module_tweetlog.Logger+w)
+    * [.e(...args)](#module_tweetlog.Logger+e)
+
+<a name="module_tweetlog.Logger+tag"></a>
+
+#### logger.tag
+The tag this logger instance was created with.
+
+**Kind**: instance property of [<code>Logger</code>](#module_tweetlog.Logger)  
+<a name="module_tweetlog.Logger+t"></a>
+
+#### logger.t(...args)
+Log a message at trace (t) level
+
+**Kind**: instance method of [<code>Logger</code>](#module_tweetlog.Logger)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| ...args | <code>\*</code> | any log message parameters |
+
+<a name="module_tweetlog.Logger+d"></a>
+
+#### logger.d(...args)
+Log a message at debug (d) level
+
+**Kind**: instance method of [<code>Logger</code>](#module_tweetlog.Logger)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| ...args | <code>\*</code> | any log message parameters |
+
+<a name="module_tweetlog.Logger+i"></a>
+
+#### logger.i(...args)
+Log a message at info (i) level
+
+**Kind**: instance method of [<code>Logger</code>](#module_tweetlog.Logger)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| ...args | <code>\*</code> | any log message parameters |
+
+<a name="module_tweetlog.Logger+w"></a>
+
+#### logger.w(...args)
+Log a message at warn (w) level
+
+**Kind**: instance method of [<code>Logger</code>](#module_tweetlog.Logger)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| ...args | <code>\*</code> | any log message parameters |
+
+<a name="module_tweetlog.Logger+e"></a>
+
+#### logger.e(...args)
+Log a message at error (e) level
+
+**Kind**: instance method of [<code>Logger</code>](#module_tweetlog.Logger)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| ...args | <code>\*</code> | any log message parameters |
+
+<a name="module_tweetlog..console"></a>
+
+### tweetlog~console(level, tag, ...args)
+A log listener callback handler that logs to the javascript console.
+Logs at level info or less will be `console.log`-ed.
+Logs at level warning or greater will be `console.error`-ed if available.
+
+**Kind**: inner method of [<code>tweetlog</code>](#module_tweetlog)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| level | <code>string</code> | single character log level (one of 'tdiwe') |
+| tag | <code>string</code> | the logger tag |
+| ...args | <code>\*</code> | any log message parameters |
+
+<a name="module_tweetlog..set"></a>
+
+### tweetlog~set(level, [tag])
+Set a global logging level, or a level for a specific tag.
+
+**Kind**: inner method of [<code>tweetlog</code>](#module_tweetlog)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| level | <code>string</code> | a single character logging level (one of 'tdiwe') |
+| [tag] | <code>string</code> | the tag, if setting a tag specific level |
+
+<a name="module_tweetlog..listen"></a>
+
+### tweetlog~listen(listener)
+Register a log listener / aggregator to handle log messages.
+For a simple console logging example, see the included `tweetlog.console`
+
+**Kind**: inner method of [<code>tweetlog</code>](#module_tweetlog)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| listener | <code>function</code> | the listener callback |
+
+**Example**  
+```js
+const tweetlog = require('tweetlog')
+tweetlog.listen(tweetlog.console)
+```
+<a name="module_tweetlog..unlisten"></a>
+
+### tweetlog~unlisten(listener)
+Unregister a previously registered log listener.
+
+**Kind**: inner method of [<code>tweetlog</code>](#module_tweetlog)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| listener | <code>function</code> | the listener callback to remove |
+
+<a name="module_tweetlog..unlistenAll"></a>
+
+### tweetlog~unlistenAll()
+Unregister all previously registered log listeners.
+
+**Kind**: inner method of [<code>tweetlog</code>](#module_tweetlog)  
+<a name="module_tweetlog..resetLevels"></a>
+
+### tweetlog~resetLevels()
+Set global log level to info (i) and remove all tag overrides.
+
+**Kind**: inner method of [<code>tweetlog</code>](#module_tweetlog)  
+<a name="module_tweetlog..gte"></a>
+
+### tweetlog~gte(a, b) ⇒ <code>boolean</code>
+**Kind**: inner method of [<code>tweetlog</code>](#module_tweetlog)  
+**Returns**: <code>boolean</code> - - true if a is >= b  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| a | <code>string</code> | single character log level (one of 'tdiwe') |
+| b | <code>string</code> | single character log level (one of 'tdiwe') |
+
+<a name="module_tweetlog..should"></a>
+
+### tweetlog~should(level, [tag])
+Given a log level and tag, determine if logger would log this level.
+Can be used to short-circuit computationally intensive logging.
+
+**Kind**: inner method of [<code>tweetlog</code>](#module_tweetlog)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| level | <code>string</code> | single character log level (one of 'tdiwe') |
+| [tag] | <code>string</code> | the tag to check, or global if unspecified |
+
+**Example**  
+```js
+const tweetlog = require('tweetlog')
+const log = tweetlog('my-log')
+if (tweetlog.should('e', log.tag)) {
+  log.e(... some cpu intensive logging ...)
+}
+```

--- a/docs/tweetlog/tweetlog.md
+++ b/docs/tweetlog/tweetlog.md
@@ -38,7 +38,7 @@ log.e('circumstance a', new Error('something bad'))
         * [~unlistenAll()](#module_tweetlog..unlistenAll)
         * [~resetLevels()](#module_tweetlog..resetLevels)
         * [~gte(a, b)](#module_tweetlog..gte) ⇒ <code>boolean</code>
-        * [~should(level, [tag])](#module_tweetlog..should)
+        * [~should(level, [tag])](#module_tweetlog..should) ⇒ <code>boolean</code>
 
 <a name="module_tweetlog.Logger"></a>
 
@@ -196,11 +196,12 @@ Set global log level to info (i) and remove all tag overrides.
 
 <a name="module_tweetlog..should"></a>
 
-### tweetlog~should(level, [tag])
+### tweetlog~should(level, [tag]) ⇒ <code>boolean</code>
 Given a log level and tag, determine if logger would log this level.
 Can be used to short-circuit computationally intensive logging.
 
 **Kind**: inner method of [<code>tweetlog</code>](#module_tweetlog)  
+**Returns**: <code>boolean</code> - if this log would be logged  
 
 | Param | Type | Description |
 | --- | --- | --- |

--- a/packages/hackmode/lib/index.js
+++ b/packages/hackmode/lib/index.js
@@ -12,17 +12,10 @@ const PeerInfo = require('peer-info')
 const PeerId = require('peer-id')
 
 const tweetlog = require('@holochain/tweetlog')
-tweetlog.set('t')
-
-/// in hackmode, we need to always output on stderr
-tweetlog.listen((l, t, ...a) => {
-  console.error(`(${t}) [${l}] ${a.map(a => a.stack || (Array.isArray(a) || typeof a === 'object') ? JSON.stringify(a) : a.toString()).join(' ')}`)
-})
-
 const log = tweetlog('@hackmode@')
 
 class N3hHackMode extends AsyncClass {
-  async init () {
+  async init (workDir) {
     await super.init()
 
     this._memory = {}
@@ -33,13 +26,7 @@ class N3hHackMode extends AsyncClass {
       pauseUntil: 0
     }
 
-    this._workDir = 'N3H_WORK_DIR' in process.env
-      ? process.env.N3H_WORK_DIR
-      : path.resolve(path.join(
-        os.homedir(), '.nh3'))
-
-    await mkdirp(this._workDir)
-    process.chdir(this._workDir)
+    this._workDir = workDir
 
     this._ipcUri = 'N3H_IPC_SOCKET' in process.env
       ? process.env.N3H_IPC_SOCKET

--- a/packages/n3h-mock/lib/index.js
+++ b/packages/n3h-mock/lib/index.js
@@ -8,14 +8,12 @@ const { IpcServer } = require('@holochain/n3h-ipc')
 const { Mem } = require('./mem')
 
 const tweetlog = require('@holochain/tweetlog')
-tweetlog.set('t')
-
 const log = tweetlog('@mock@')
 
 class N3hMock extends AsyncClass {
   /// Network mock init.
   /// Normally spawned by holochain_net where config is passed via environment variables
-  async init () {
+  async init (workDir) {
     await super.init()
 
     log.t('Initializing...')
@@ -26,14 +24,7 @@ class N3hMock extends AsyncClass {
     this.senders_by_dna = {}
 
     // Set working directory from config (a temp folder) or default to $home/.n3h
-    this._workDir = 'N3H_WORK_DIR' in process.env
-      ? process.env.N3H_WORK_DIR
-      : path.resolve(path.join(
-        os.homedir(), '.nh3'))
-
-    // Move into working directory?
-    await mkdirp(this._workDir)
-    process.chdir(this._workDir)
+    this._workDir = workDir
 
     // Set ipcUri
     this._ipcUri = 'N3H_IPC_SOCKET' in process.env

--- a/packages/n3h/bin/n3h
+++ b/packages/n3h/bin/n3h
@@ -34,6 +34,21 @@ async function main () {
   tweetlog.set('t') // enable trace logging
   tweetlog.listen(logHandler)
 
+  const quietMode = 'N3H_QUIET' in process.env
+  if (!quietMode) {
+    tweetlog.listen((level, tag, ...args) => {
+      args = args.map(a => {
+        if (a instanceof Error) {
+          return a.stack || a.toString()
+        } else if (typeof a === 'object') {
+          return JSON.stringify(a)
+        }
+        return a.toString()
+      })
+      console.log(`(${tag}) [${level}] ${args}`)
+    })
+  }
+
   var n3hNode
   switch(mode) {
     case 'MOCK':

--- a/packages/n3h/bin/n3h
+++ b/packages/n3h/bin/n3h
@@ -1,23 +1,49 @@
 #!/usr/bin/env node
 
+const path = require('path')
+const os = require('os')
+
+const { mkdirp } = require('@holochain/n3h-common')
+const tweetlog = require('@holochain/tweetlog')
+
+const { buildLogHandler } = require('../lib/file-logger')
 const { N3hNode, N3hHackMode, N3hMock } = require('../lib/index')
 
 async function main () {
+  const workDir = 'N3H_WORK_DIR' in process.env
+    ? process.env.N3H_WORK_DIR
+    : path.resolve(path.join(
+      os.homedir(), '.n3h'))
+
+  // Move into working directory?
+  await mkdirp(workDir)
+  process.chdir(workDir)
 
   const mode = 'N3H_MODE' in process.env
     ? process.env.N3H_MODE
     : null
 
+  const logDir = path.join(workDir, 'logs')
+  await mkdirp(logDir)
+
+  const logHandler = buildLogHandler({
+    dir: logDir
+  })
+
+  // setup logging
+  tweetlog.set('t') // enable trace logging
+  tweetlog.listen(logHandler)
+
   var n3hNode
   switch(mode) {
     case 'MOCK':
-      n3hNode = await new N3hMock()
+      n3hNode = await new N3hMock(workDir)
       break
     case 'HACK':
-      n3hNode = await new N3hHackMode()
+      n3hNode = await new N3hHackMode(workDir)
       break
     default:
-      n3hNode = await N3hNode.constructDefault()
+      n3hNode = await N3hNode.constructDefault(workDir)
   }
 
   let terminated = false
@@ -27,9 +53,13 @@ async function main () {
     }
     try {
       await n3hNode.destroy()
+      logHandler.cleanup()
       console.log('n3h exited cleanly')
       process.exit(0)
     } catch (e) {
+      try {
+        logHandler.cleanup()
+      } catch (e) { /* pass */ }
       console.error(e.stack || e.toString())
       process.exit(1)
     }

--- a/packages/n3h/lib/file-logger.js
+++ b/packages/n3h/lib/file-logger.js
@@ -1,0 +1,106 @@
+const fs = require('fs')
+const path = require('path')
+
+const RE_PATH = /[\\/]/
+
+/**
+ * Construct a tweetlog log listener that will write to rotating files
+ * @param {object} [opts]
+ * @param {string} [opts.dir] - defaults to '.'
+ * @param {string} [opts.prefix] - defaults to 'n3h-log.'
+ * @param {string} [opts.suffix] - defaults to '.log'
+ * @param {number} [opts.rotateMs] - rotate log files at this frequency, defaults to 1 hour
+ * @param {number} [opts.keepCount] - keep this count log files, defaults to 4
+ * @param {number} [opts.flushMs] - flush to file system at this frequency, defaults to 0, if <= 0, flush on every log
+ */
+exports.buildLogHandler = opts => {
+  opts || (opts = {})
+  const dir = opts.dir || '.'
+  const prefix = opts.prefix || 'n3h-log.'
+  const suffix = opts.suffix || '.log'
+  const rotateMs = opts.rotateMs || (1000 * 60 * 60)
+  const keepCount = opts.keepCount || 4
+  // const flushMs = opts.flushMs || 0
+
+  if (RE_PATH.test(prefix) || RE_PATH.test(suffix)) {
+    throw new Error('prefix / suffix cannot contain path elements')
+  }
+
+  const runtime = {
+    lastFlush: 0,
+    timeTag: 0,
+    stream: null
+  }
+
+  const cleanup = () => {
+    if (runtime.stream) {
+      runtime.stream.end()
+    }
+    runtime.lastFlush = 0
+    runtime.timeTag = 0
+    runtime.stream = null
+  }
+
+  const listener = (level, tag, ...args) => {
+    const timeTag = parseInt(Date.now() / rotateMs, 10) * rotateMs
+
+    if (timeTag !== runtime.timeTag) {
+      // fire off asynchronous prune
+      (async () => {
+        let list = fs.readdirSync(dir)
+        list = list.filter(n => n.startsWith(prefix) && n.endsWith(suffix))
+        list.sort((a, b) => {
+          a = parseInt(a.replace(prefix, '').replace(suffix, ''), 10)
+          b = parseInt(b.replace(prefix, '').replace(suffix, ''), 10)
+          return a - b
+        })
+        for (let i = 0; i < keepCount - 1; ++i) {
+          list.pop()
+        }
+        for (let file of list) {
+          file = path.join(dir, file)
+          fs.unlinkSync(file)
+        }
+      })().catch(err => {
+        console.error('LOGGING ERROR', err)
+      })
+
+      // close any old handle
+      cleanup()
+
+      const filename = path.join(dir, prefix + timeTag + suffix)
+
+      runtime.stream = fs.createWriteStream(
+        filename,
+        {
+          flags: 'a'
+        }
+      )
+    }
+
+    runtime.stream.write(`~*~ ${_renderTime()} (${tag}) [${level}] ${_renderArgs(args)}\n`)
+  }
+
+  listener.cleanup = cleanup
+
+  return listener
+}
+
+/**
+ */
+function _renderTime () {
+  return (new Date()).toLocaleString() + ' - ' + Date.now()
+}
+
+/**
+ */
+function _renderArgs (args) {
+  return args.map(a => {
+    if (a instanceof Error) {
+      return a.stack || a.toString()
+    } else if (typeof a === 'object') {
+      return JSON.stringify(a)
+    }
+    return a.toString()
+  }).join('\n')
+}

--- a/packages/n3h/lib/file-logger.js
+++ b/packages/n3h/lib/file-logger.js
@@ -7,8 +7,8 @@ const RE_PATH = /[\\/]/
  * Construct a tweetlog log listener that will write to rotating files
  * @param {object} [opts]
  * @param {string} [opts.dir] - defaults to '.'
- * @param {string} [opts.prefix] - defaults to 'n3h-log.'
- * @param {string} [opts.suffix] - defaults to '.log'
+ * @param {string} [opts.prefix] - defaults to ''
+ * @param {string} [opts.suffix] - defaults to '.n3h.log'
  * @param {number} [opts.rotateMs] - rotate log files at this frequency, defaults to 1 hour
  * @param {number} [opts.keepCount] - keep this count log files, defaults to 4
  * @param {number} [opts.flushMs] - flush to file system at this frequency, defaults to 0, if <= 0, flush on every log
@@ -16,8 +16,8 @@ const RE_PATH = /[\\/]/
 exports.buildLogHandler = opts => {
   opts || (opts = {})
   const dir = opts.dir || '.'
-  const prefix = opts.prefix || 'n3h-log.'
-  const suffix = opts.suffix || '.log'
+  const prefix = opts.prefix || ''
+  const suffix = opts.suffix || '.n3h.log'
   const rotateMs = opts.rotateMs || (1000 * 60 * 60)
   const keepCount = opts.keepCount || 4
   // const flushMs = opts.flushMs || 0

--- a/packages/n3h/lib/file-logger.test.js
+++ b/packages/n3h/lib/file-logger.test.js
@@ -28,10 +28,17 @@ describe('file-logger Suite', () => {
 
     // for windows... looks like we need to manually remove
     for (let file of fs.readdirSync(d.name)) {
-      fs.unlinkSync(path.join(d.name, file))
+      try {
+        fs.unlinkSync(path.join(d.name, file))
+      } catch (e) { /* pass */ }
     }
 
-    d.removeCallback()
+    await $sleep(0)
+
+    try {
+      d.removeCallback()
+    } catch (e) { /* pass */ }
+
     d = null
 
     l.cleanup()

--- a/packages/n3h/lib/file-logger.test.js
+++ b/packages/n3h/lib/file-logger.test.js
@@ -22,9 +22,18 @@ describe('file-logger Suite', () => {
     })
   })
 
-  afterEach(() => {
+  afterEach(async () => {
+    // some time for file creation to proceed
+    await $sleep(10)
+
+    // for windows... looks like we need to manually remove
+    for (let file of fs.readdirSync(d.name)) {
+      fs.unlinkSync(path.join(d.name, file))
+    }
+
     d.removeCallback()
     d = null
+
     l.cleanup()
     l = null
   })
@@ -38,7 +47,7 @@ describe('file-logger Suite', () => {
     await $sleep(10)
     l('w', 'test', 'four')
     await $sleep(0)
-    expect(fs.readdirSync(d.name).length).lessThan(3)
+    expect(fs.readdirSync(d.name).length).lessThan(4)
   })
 
   it('should log', async () => {

--- a/packages/n3h/lib/file-logger.test.js
+++ b/packages/n3h/lib/file-logger.test.js
@@ -1,0 +1,52 @@
+const { expect } = require('chai')
+const { $sleep } = require('@holochain/n3h-common')
+const fs = require('fs')
+const path = require('path')
+const tmp = require('tmp')
+tmp.setGracefulCleanup()
+
+const { buildLogHandler } = require('./file-logger')
+
+describe('file-logger Suite', () => {
+  let d = null
+  let l = null
+
+  beforeEach(() => {
+    d = tmp.dirSync({
+      unsafeCleanup: true
+    })
+    l = buildLogHandler({
+      dir: d.name,
+      rotateMs: 5,
+      keepCount: 2
+    })
+  })
+
+  afterEach(() => {
+    d.removeCallback()
+    d = null
+    l.cleanup()
+    l = null
+  })
+
+  it('should log and prune', async () => {
+    l('w', 'test', 'one')
+    await $sleep(10)
+    l('w', 'test', 'two')
+    await $sleep(10)
+    l('w', 'test', 'three')
+    await $sleep(10)
+    l('w', 'test', 'four')
+    await $sleep(0)
+    expect(fs.readdirSync(d.name).length).lessThan(3)
+  })
+
+  it('should log', async () => {
+    l('w', 'test', 'one')
+    await $sleep(10)
+    const f = path.join(d.name, fs.readdirSync(d.name)[0])
+    const data = fs.readFileSync(f).toString()
+    expect(data).contains('~*~')
+    expect(data).contains('(test) [w] one')
+  })
+})

--- a/packages/n3h/lib/index.js
+++ b/packages/n3h/lib/index.js
@@ -1,8 +1,8 @@
 const path = require('path')
 const os = require('os')
 const { URL } = require('url')
-
 const { AsyncClass, mkdirp, ModMod } = require('@holochain/n3h-common')
+
 const { IpcServer } = require('@holochain/n3h-ipc')
 
 const DEFAULT_MODULES = [
@@ -19,22 +19,16 @@ exports.N3hMock = require('@holochain/n3h-mock').N3hMock
 class N3hNode extends AsyncClass {
   /**
    */
-  static async constructDefault (modules) {
-    return new N3hNode((modules || []).concat(DEFAULT_MODULES))
+  static async constructDefault (workDir, modules) {
+    return new N3hNode(workDir, (modules || []).concat(DEFAULT_MODULES))
   }
 
   /**
    */
-  async init (modules) {
+  async init (workDir, modules) {
     await super.init()
 
-    this._workDir = 'N3H_WORK_DIR' in process.env
-      ? process.env.N3H_WORK_DIR
-      : path.resolve(path.join(
-        os.homedir(), '.nh3'))
-
-    await mkdirp(this._workDir)
-    process.chdir(this._workDir)
+    this._workDir = workDir
 
     this._ipcUri = 'N3H_IPC_SOCKET' in process.env
       ? process.env.N3H_IPC_SOCKET

--- a/packages/n3h/package.json
+++ b/packages/n3h/package.json
@@ -17,7 +17,8 @@
     "nyc": "^12.0.2",
     "opn": "^5.4.0",
     "sinon": "^7.1.1",
-    "standard": "^12.0.1"
+    "standard": "^12.0.1",
+    "tmp": "0.0.33"
   },
   "dependencies": {
     "@holochain/hackmode": "^0.0.1",

--- a/packages/tweetlog/lib/tweetlog.js
+++ b/packages/tweetlog/lib/tweetlog.js
@@ -121,6 +121,7 @@
  * @function should
  * @param {string} level - single character log level (one of 'tdiwe')
  * @param {string} [tag] - the tag to check, or global if unspecified
+ * @return {boolean} if this log would be logged
  * @example
  *
  * const tweetlog = require('tweetlog')

--- a/packages/tweetlog/lib/tweetlog.js
+++ b/packages/tweetlog/lib/tweetlog.js
@@ -1,3 +1,136 @@
+/**
+ * A bare-bones logging helper for light-weight javascript logging.
+ * This module itself is a function that returns a logger instance
+ * when given a tag.
+ *
+ * tweetlog (without api comments / tests) currently fits into 5 tweets.
+ * Homage to https://tweetnacl.cr.yp.to/
+ *
+ * @module tweetlog
+ * @param {string} tag - a logging tag to mark messages
+ * @return {Logger}
+ * @example
+ *
+ * const tweetlog = require('tweetlog')
+ * tweetlog.listen(tweetlog.console)
+ * const log = tweetlog('my-log')
+ * log.e('circumstance a', new Error('something bad'))
+ */
+
+/**
+ * A tagged logger instance
+ * @namespace Logger
+ * @memberof module:tweetlog
+ */
+
+/**
+ * The tag this logger instance was created with.
+ * @member tag
+ * @memberof module:tweetlog.Logger#
+ */
+
+/**
+ * Log a message at trace (t) level
+ * @function t
+ * @memberof module:tweetlog.Logger#
+ * @param {...*} args - any log message parameters
+ */
+
+/**
+ * Log a message at debug (d) level
+ * @function d
+ * @memberof module:tweetlog.Logger#
+ * @param {...*} args - any log message parameters
+ */
+
+/**
+ * Log a message at info (i) level
+ * @function i
+ * @memberof module:tweetlog.Logger#
+ * @param {...*} args - any log message parameters
+ */
+
+/**
+ * Log a message at warn (w) level
+ * @function w
+ * @memberof module:tweetlog.Logger#
+ * @param {...*} args - any log message parameters
+ */
+
+/**
+ * Log a message at error (e) level
+ * @function e
+ * @memberof module:tweetlog.Logger#
+ * @param {...*} args - any log message parameters
+ */
+
+/**
+ * A log listener callback handler that logs to the javascript console.
+ * Logs at level info or less will be `console.log`-ed.
+ * Logs at level warning or greater will be `console.error`-ed if available.
+ * @function console
+ * @param {string} level - single character log level (one of 'tdiwe')
+ * @param {string} tag - the logger tag
+ * @param {...*} args - any log message parameters
+ */
+
+/**
+ * Set a global logging level, or a level for a specific tag.
+ * @function set
+ * @param {string} level - a single character logging level (one of 'tdiwe')
+ * @param {string} [tag] - the tag, if setting a tag specific level
+ */
+
+/**
+ * Register a log listener / aggregator to handle log messages.
+ * For a simple console logging example, see the included `tweetlog.console`
+ * @function listen
+ * @param {function} listener - the listener callback
+ * @example
+ *
+ * const tweetlog = require('tweetlog')
+ * tweetlog.listen(tweetlog.console)
+ */
+
+/**
+ * Unregister a previously registered log listener.
+ * @function unlisten
+ * @param {function} listener - the listener callback to remove
+ */
+
+/**
+ * Unregister all previously registered log listeners.
+ * @function unlistenAll
+ */
+
+/**
+ * Set global log level to info (i) and remove all tag overrides.
+ * @function resetLevels
+ */
+
+/**
+ * @function gte
+ * @param {string} a - single character log level (one of 'tdiwe')
+ * @param {string} b - single character log level (one of 'tdiwe')
+ * @return {boolean} - true if a is >= b
+ */
+
+/**
+ * Given a log level and tag, determine if logger would log this level.
+ * Can be used to short-circuit computationally intensive logging.
+ * @function should
+ * @param {string} level - single character log level (one of 'tdiwe')
+ * @param {string} [tag] - the tag to check, or global if unspecified
+ * @example
+ *
+ * const tweetlog = require('tweetlog')
+ * const log = tweetlog('my-log')
+ * if (tweetlog.should('e', log.tag)) {
+ *   log.e(... some cpu intensive logging ...)
+ * }
+ */
+
+// -- begin tweetlog -- //
 const _ = { t: 1, d: 2, i: 3, w: 4, e: 5 }
 const $ = []
 let c = { _: 'i' }
@@ -6,8 +139,9 @@ const e = (...a) => {
     try { l(...a) } catch (e) {}
   }
 }
+// --
 const f = module.exports = (t) => {
-  const o = {}
+  const o = { tag: t }
   ;['t', 'd', 'i', 'w', 'e'].forEach((l) => {
     o[l] = (...a) => {
       if (!f.should(l, t)) return
@@ -16,22 +150,32 @@ const f = module.exports = (t) => {
   })
   return o
 }
+// --
+f.set = (l, t) => {
+  c[t || '_'] = l
+}
+f.listen = $.push.bind($)
+f.unlisten = l => {
+  const i = $.indexOf(l)
+  i > -1 && $.splice(i, 1)
+}
+f.unlistenAll = () => {
+  $.splice(0)
+}
+f.resetLevels = () => {
+  c = { _: 'i' }
+}
+// --
 f.gte = (a, b) => {
   return _[a] >= _[b]
 }
 f.should = (l, t) => {
   return f.gte(l, c.t || c._)
 }
-f.set = (l, t) => {
-  c[t || '_'] = l
-}
-f.listen = $.push.bind($)
-f.clear = () => {
-  $.splice(0)
-  c = { _: 'i' }
-}
 const $l = console.log.bind(console)
 const $e = console.error ? console.error.bind(console) : $l
+// --
 f.console = (l, t, ...a) => {
   (f.gte(l, 'w') ? $e : $l)(`(${t}) [${l}] ${a.map((a) => a.stack || a.toString()).join(' ')}`)
 }
+// -- end tweetlog -- //

--- a/packages/tweetlog/lib/tweetlog.test.js
+++ b/packages/tweetlog/lib/tweetlog.test.js
@@ -8,7 +8,8 @@ const logger = require('./tweetlog')
 
 describe('tweetlog Suite', () => {
   beforeEach(() => {
-    logger.clear()
+    logger.unlistenAll()
+    logger.resetLevels()
   })
 
   afterEach(() => {
@@ -89,6 +90,15 @@ describe('tweetlog Suite', () => {
     logger.listen(s)
     logger('test').t('test')
     expect(s.calledWith('t', 'test', 'test')).equals(true)
+  })
+
+  it('should unlisten', () => {
+    logger.set('t')
+    const s = sinon.stub()
+    logger.listen(s)
+    logger.unlisten(s)
+    logger('test').t('test')
+    expect(s.callCount).equals(0)
   })
 
   it('should output to console.error', () => {

--- a/packages/tweetlog/package.json
+++ b/packages/tweetlog/package.json
@@ -40,5 +40,8 @@
       "lcov",
       "text-summary"
     ]
+  },
+  "generate-docs": {
+    "tweetlog": "lib/tweetlog.js"
   }
 }


### PR DESCRIPTION
@ddd-mtl - let me know what you think about this.

I'm getting to the point where I want to just spam log messages all over the place for debugging, but it makes it hard to see what's going on when those logs are going to stdout. This change adds an auto-rotated file logger to n3h, currently set to switch files every hour, and keep 4 hours on disk.

My main question is:
- [x] Do you think we should * also * log to stdout for debugging ease, or are the files good enough?

Also, this adds api docs for tweetlog since reading that code is almost impossible: https://github.com/holochain/n3h/blob/tweetlog/docs/tweetlog/tweetlog.md