### PR TITLE
fix peer discovery gossip bug

### DIFF
--- a/packages/hackmode/lib/index.js
+++ b/packages/hackmode/lib/index.js
@@ -115,7 +115,7 @@ class N3hHackMode extends AsyncClass {
       return
     }
 
-    // log.t('Received IPC message: ', opt)
+    log.t('Received IPC message: ', opt)
 
     let ref
     let tId
@@ -172,6 +172,7 @@ class N3hHackMode extends AsyncClass {
         case 'sendMessage':
           ref = this._getMemRef(opt.data.dnaAddress)
           if (!(opt.data.toAgentId in ref.agentToTransportId)) {
+            log.w('NO ROUTE FOR sendMessage', opt.data)
             this._ipc.send('json', {
               method: 'failureResult',
               dnaAddress: opt.data.dnaAddress,
@@ -496,6 +497,8 @@ class N3hHackMode extends AsyncClass {
         this._processGetDataResp(opt.data.dnaAddress, opt.data.data)
         return
       case 'handleSendMessage':
+        log.t('P2P handleSendMessage', opt.data)
+
         // transcribe to IPC
         this._ipc.send('json', {
           method: 'handleSendMessage',
@@ -507,6 +510,8 @@ class N3hHackMode extends AsyncClass {
         })
         return
       case 'sendMessageResult':
+        log.t('P2P sendMessageResult', opt.data)
+
         // transcribe to IPC
         this._ipc.send('json', {
           method: 'sendMessageResult',
@@ -648,6 +653,7 @@ class N3hHackMode extends AsyncClass {
       const ref = this._memory[dnaAddress].mem
       if (ref.has(hash)) {
         const data = ref.get(hash)
+        log.w('sending gossip data', data)
         this._p2p.send(fromId, {
           type: 'getDataResp',
           dnaAddress: dnaAddress,
@@ -714,7 +720,7 @@ class N3hHackMode extends AsyncClass {
         mem,
         agentToTransportId: mem.registerIndexer((store, data) => {
           if (data && data.type === 'agent') {
-            log.t('got peer', data)
+            log.t('PEER INDEXED', data)
             store[data.agentId] = data.transportId
             this._ipc.send('json', {
               method: 'peerConnected',
@@ -737,13 +743,15 @@ class N3hHackMode extends AsyncClass {
   }
 
   _track (dnaAddress, agentId) {
+    log.t('REGISTER AGENT', dnaAddress, agentId)
+
     const ref = this._getMemRef(dnaAddress)
     // store agent (this will map agentId to transportId)
     ref.mem.insert({
       type: 'agent',
       dnaAddress: dnaAddress,
       agentId: agentId,
-      address: agentId,
+      address: 'hackmode:peer:discovery:' + agentId,
       transportId: this._p2p.getId()
     })
 


### PR DESCRIPTION
RE https://github.com/holochain/simple-app/blob/steps-to-reproduce/README.md

Ha! now that agent entries are properly using the agentId as their address, they were over-writing a bit of peer discovery gossip that N3H was making use of. Changed the internal bookkeeping entry to be distinct, and now we should be able to route messages to other nodes again :+1: 

Thanks for your debugging @Connoropolous / @philipbeadle / @willemolding it was a massive help in narrowing this down.