### PR TITLE
"untrackDna"

### DIFF
--- a/packages/hackmode/lib/index.js
+++ b/packages/hackmode/lib/index.js
@@ -129,20 +129,11 @@ class N3hHackMode extends AsyncClass {
           if (bucketId !== '') {
             return
           }
-          // if not relay to sender
-          ref = this._getMemRef(opt.data.dnaAddress)
-          if (!(opt.data.toAgentId in ref.agentToTransportId)) {
-            // Sending failureResult failed...
-            this._ipc.send('json', {
-              method: 'failureResult',
-              dnaAddress: opt.data.dnaAddress,
-              _id: opt.data._id,
-              toAgentId: opt.data.agentId,
-              errorInfo: 'No routing for agent id "' + opt.data.requesterAgentId + '" aborting failureResult'
-            })
+          // if not relay to receipient if possible
+          tId = this._getTransportIdOrFail(opt.data.dnaAddress, opt.data.toAgentId)
+          if (tId === null) {
             return
           }
-          tId = ref.agentToTransportId[opt.data.toAgentId]
           this._p2p.send(tId, {
             type: 'failureResult',
             dnaAddress: opt.data.dnaAddress,
@@ -167,22 +158,26 @@ class N3hHackMode extends AsyncClass {
           })
           return
         case 'trackDna':
+          // Note: opt.data is a TrackDnaData
           this._track(opt.data.dnaAddress, opt.data.agentId)
           return
-        case 'sendMessage':
-          ref = this._getMemRef(opt.data.dnaAddress)
-          if (!(opt.data.toAgentId in ref.agentToTransportId)) {
-            log.w('NO ROUTE FOR sendMessage', opt.data)
-            this._ipc.send('json', {
-              method: 'failureResult',
-              dnaAddress: opt.data.dnaAddress,
-              _id: opt.data._id,
-              toAgentId: opt.data.fromAgentId,
-              errorInfo: 'No routing for agent id "' + opt.data.toAgentId + '" aborting sendMessage'
-            })
+        case 'untrackDna':
+          // Note: opt.data is a TrackDnaData
+          tId = this._getTransportIdOrFail(opt.data.dnaAddress, opt.data.agentId)
+          if (tId === null) {
             return
           }
-          tId = ref.agentToTransportId[opt.data.toAgentId]
+          this._untrack(opt.data.dnaAddress, opt.data.agentId)
+          return
+        case 'sendMessage':
+          // Note: opt.data is a MessageData
+          if (this._getTransportIdOrFail(opt.data.dnaAddress, opt.data.fromAgentId, opt.data.fromAgentId, opt.data._id) === null) {
+            return
+          }
+          tId = this._getTransportIdOrFail(opt.data.dnaAddress, opt.data.toAgentId, opt.data.fromAgentId, opt.data._id)
+          if (tId === null) {
+            return
+          }
           this._p2p.send(tId, {
             type: 'handleSendMessage',
             _id: opt.data._id,
@@ -193,18 +188,14 @@ class N3hHackMode extends AsyncClass {
           })
           return
         case 'handleSendMessageResult':
-          ref = this._getMemRef(opt.data.dnaAddress)
-          if (!(opt.data.toAgentId in ref.agentToTransportId)) {
-            this._ipc.send('json', {
-              method: 'failureResult',
-              dnaAddress: opt.data.dnaAddress,
-              _id: opt.data._id,
-              toAgentId: opt.data.fromAgentId,
-              errorInfo: 'No routing for agent id "' + opt.data.toAgentId + '" aborting handleSendMessageResult'
-            })
+          // Note: opt.data is a MessageData
+          if (this._getTransportIdOrFail(opt.data.dnaAddress, opt.data.fromAgentId, opt.data.fromAgentId, opt.data._id) === null) {
             return
           }
-          tId = ref.agentToTransportId[opt.data.toAgentId]
+          tId = this._getTransportIdOrFail(opt.data.dnaAddress, opt.data.toAgentId, opt.data.fromAgentId, opt.data._id)
+          if (tId === null) {
+            return
+          }
           this._p2p.send(tId, {
             type: 'sendMessageResult',
             _id: opt.data._id,
@@ -216,6 +207,9 @@ class N3hHackMode extends AsyncClass {
           return
         case 'publishEntry':
           // Note: opt.data is a EntryData
+          if (this._getTransportIdOrFail(opt.data.dnaAddress, opt.data.providerAgentId) === null) {
+            return
+          }
           // Bookkeep
           this._bookkeepAddress(this._publishedEntryBook, opt.data.dnaAddress, opt.data.address)
           // publish
@@ -228,6 +222,9 @@ class N3hHackMode extends AsyncClass {
           return
         case 'publishMeta':
           // Note: opt.data is a DhtMetaData
+          if (this._getTransportIdOrFail(opt.data.dnaAddress, opt.data.providerAgentId) === null) {
+            return
+          }
           // Bookkeep each metaId
           for (const metaContent of opt.data.contentList) {
             let metaId = this._metaIdFromTuple(opt.data.entryAddress, opt.data.attribute, metaContent)
@@ -244,12 +241,19 @@ class N3hHackMode extends AsyncClass {
           })
           return
         case 'fetchEntry':
+          // Note: opt.data is a FetchEntryData
+          if (this._getTransportIdOrFail(opt.data.dnaAddress, opt.data.requesterAgentId) === null) {
+            return
+          }
           //  since we're fully connected, just redirect this back to itself for now...
           opt.data.method = 'handleFetchEntry'
           this._ipc.send('json', opt.data)
           return
         case 'handleFetchEntryResult':
           // Note: opt.data is a FetchEntryResultData
+          if (this._getTransportIdOrFail(opt.data.dnaAddress, opt.data.providerAgentId, opt.data.requesterAgentId, opt.data._id) === null) {
+            return
+          }
           // if this message is a response from our own request, do a publish
           bucketId = this._checkRequest(opt.data._id)
           if (bucketId !== '') {
@@ -289,6 +293,10 @@ class N3hHackMode extends AsyncClass {
           })
           return
         case 'fetchMeta':
+          // Note: opt.data is a FetchMetaData
+          if (this._getTransportIdOrFail(opt.data.dnaAddress, opt.data.requesterAgentId) === null) {
+            return
+          }
           // erm... since we're fully connected,
           // just redirect this back to itself for now...
           opt.data.method = 'handleFetchMeta'
@@ -296,6 +304,9 @@ class N3hHackMode extends AsyncClass {
           return
         case 'handleFetchMetaResult':
           // Note: opt.data is a FetchMetaResultData
+          if (this._getTransportIdOrFail(opt.data.dnaAddress, opt.data.providerAgentId, opt.data.requesterAgentId, opt.data._id) === null) {
+            return
+          }
           ref = this._getMemRef(opt.data.dnaAddress)
           // if its from our own request, do a publish for each new/unknown meta content
           bucketId = this._checkRequest(opt.data._id)
@@ -791,6 +802,54 @@ class N3hHackMode extends AsyncClass {
     let bucketId = this._requestBook.get(requestId)
     this._requestBook.delete(requestId)
     return bucketId
+  }
+
+  /**
+   *  Check if agent is tracking dna.
+   *  If not, will try to send a FailureResult back to sender (if sender info is provided).
+   *  Returns transportId of receiverAgentId if agent is tracking dna.
+   */
+  _getTransportIdOrFail (dnaAddress, receiverAgentId, senderAgentId, requestId) {
+    // get memory slice
+    let ref = this._getMemRef(dnaAddress)
+    // Check if receiver is known
+    // if (ref.agentToTransportId[receiverAgentId] !== undefined) {
+    if (receiverAgentId in ref.agentToTransportId) {
+      log.t('oooo CHECK OK for "' + receiverAgentId + '" for DNA "' + dnaAddress + '" = ' + ref.agentToTransportId[receiverAgentId])
+      return ref.agentToTransportId[receiverAgentId]
+    }
+    // Send FailureResult back to IPC, should be senderAgentId
+    log.e('#### Check failed for "' + receiverAgentId + '" for DNA "' + dnaAddress + '"')
+    this._ipc.send('json', {
+      method: 'failureResult',
+      dnaAddress: dnaAddress,
+      _id: requestId,
+      toAgentId: senderAgentId,
+      errorInfo: 'No routing for agent id "' + receiverAgentId + '"'
+    })
+    // Done
+    return null
+  }
+
+  /**
+   * We can't remove a mem entry but we can update it, so we update the transportId to undefined
+   * to signify that this agent is no longer part of this DNA
+   */
+  _untrack (dnaAddress, agentId) {
+    // get mem slice
+    const ref = this._getMemRef(dnaAddress)
+    // create data entry
+    const agent = {
+      type: 'agent',
+      dnaAddress: dnaAddress,
+      agentId: agentId,
+      address: 'hackmode:peer:discovery:' + agentId,
+      transportId: undefined
+    }
+    log.t('_untrack() for "' + agentId + '" for DNA "' + dnaAddress + '"')
+
+    // store agent (this will map agentId to transportId)
+    ref.mem.insert(agent)
   }
 
   _track (dnaAddress, agentId) {

--- a/packages/hackmode/lib/index.js
+++ b/packages/hackmode/lib/index.js
@@ -813,8 +813,8 @@ class N3hHackMode extends AsyncClass {
     // get memory slice
     let ref = this._getMemRef(dnaAddress)
     // Check if receiver is known
-    // if (ref.agentToTransportId[receiverAgentId] !== undefined) {
-    if (receiverAgentId in ref.agentToTransportId) {
+     if (ref.agentToTransportId[receiverAgentId] !== undefined &&
+       ref.agentToTransportId[receiverAgentId] !== null) {
       log.t('oooo CHECK OK for "' + receiverAgentId + '" for DNA "' + dnaAddress + '" = ' + ref.agentToTransportId[receiverAgentId])
       return ref.agentToTransportId[receiverAgentId]
     }
@@ -844,7 +844,7 @@ class N3hHackMode extends AsyncClass {
       dnaAddress: dnaAddress,
       agentId: agentId,
       address: 'hackmode:peer:discovery:' + agentId,
-      transportId: undefined
+      transportId: null
     }
     log.t('_untrack() for "' + agentId + '" for DNA "' + dnaAddress + '"')
 

--- a/packages/hackmode/lib/index.js
+++ b/packages/hackmode/lib/index.js
@@ -813,8 +813,8 @@ class N3hHackMode extends AsyncClass {
     // get memory slice
     let ref = this._getMemRef(dnaAddress)
     // Check if receiver is known
-     if (ref.agentToTransportId[receiverAgentId] !== undefined &&
-       ref.agentToTransportId[receiverAgentId] !== null) {
+    if (ref.agentToTransportId[receiverAgentId] !== undefined &&
+      ref.agentToTransportId[receiverAgentId] !== null) {
       log.t('oooo CHECK OK for "' + receiverAgentId + '" for DNA "' + dnaAddress + '" = ' + ref.agentToTransportId[receiverAgentId])
       return ref.agentToTransportId[receiverAgentId]
     }

--- a/packages/hackmode/lib/index.js
+++ b/packages/hackmode/lib/index.js
@@ -171,9 +171,11 @@ class N3hHackMode extends AsyncClass {
           return
         case 'sendMessage':
           // Note: opt.data is a MessageData
+          // Sender must TrackDna
           if (this._getTransportIdOrFail(opt.data.dnaAddress, opt.data.fromAgentId, opt.data.fromAgentId, opt.data._id) === null) {
             return
           }
+          // Receiver must TrackDna
           tId = this._getTransportIdOrFail(opt.data.dnaAddress, opt.data.toAgentId, opt.data.fromAgentId, opt.data._id)
           if (tId === null) {
             return
@@ -189,9 +191,11 @@ class N3hHackMode extends AsyncClass {
           return
         case 'handleSendMessageResult':
           // Note: opt.data is a MessageData
+          // Sender must TrackDna
           if (this._getTransportIdOrFail(opt.data.dnaAddress, opt.data.fromAgentId, opt.data.fromAgentId, opt.data._id) === null) {
             return
           }
+          // Receiver must TrackDna
           tId = this._getTransportIdOrFail(opt.data.dnaAddress, opt.data.toAgentId, opt.data.fromAgentId, opt.data._id)
           if (tId === null) {
             return
@@ -813,8 +817,7 @@ class N3hHackMode extends AsyncClass {
     // get memory slice
     let ref = this._getMemRef(dnaAddress)
     // Check if receiver is known
-    if (ref.agentToTransportId[receiverAgentId] !== undefined &&
-      ref.agentToTransportId[receiverAgentId] !== null) {
+    if (ref.agentToTransportId[receiverAgentId]) {
       log.t('oooo CHECK OK for "' + receiverAgentId + '" for DNA "' + dnaAddress + '" = ' + ref.agentToTransportId[receiverAgentId])
       return ref.agentToTransportId[receiverAgentId]
     }

--- a/packages/hackmode/lib/index.js
+++ b/packages/hackmode/lib/index.js
@@ -231,7 +231,7 @@ class N3hHackMode extends AsyncClass {
           // Bookkeep each metaId
           for (const metaContent of opt.data.contentList) {
             let metaId = this._metaIdFromTuple(opt.data.entryAddress, opt.data.attribute, metaContent)
-          this._bookkeepAddress(this._publishedMetaBook, opt.data.dnaAddress, metaId)
+            this._bookkeepAddress(this._publishedMetaBook, opt.data.dnaAddress, metaId)
           }
           // publish
           log.t('publishMeta', opt.data.contentList)
@@ -320,12 +320,12 @@ class N3hHackMode extends AsyncClass {
               this._bookkeepAddress(isPublish ? this._publishedMetaBook : this._storedMetaBook, opt.data.dnaAddress, metaId)
               log.t('handleFetchMetaResult insert:', metaContent, opt.data.providerAgentId, metaId, isPublish)
               ref.mem.insertMeta({
-              type: 'dhtMeta',
-              providerAgentId: opt.data.providerAgentId,
-              entryAddress: opt.data.entryAddress,
-              attribute: opt.data.attribute,
+                type: 'dhtMeta',
+                providerAgentId: opt.data.providerAgentId,
+                entryAddress: opt.data.entryAddress,
+                attribute: opt.data.attribute,
                 contentList: [metaContent]
-            })
+              })
             }
             return
           }
@@ -752,7 +752,7 @@ class N3hHackMode extends AsyncClass {
               log.t('metaContent is known:', metaContent)
               continue
             }
-          this._bookkeepAddress(this._storedMetaBook, dnaAddress, metaId)
+            this._bookkeepAddress(this._storedMetaBook, dnaAddress, metaId)
             toStoreList.push(metaContent)
           }
           log.t('Sending IPC handleStoreMeta: ', toStoreList)

--- a/packages/n3h-mock/lib/index.js
+++ b/packages/n3h-mock/lib/index.js
@@ -567,8 +567,7 @@ class N3hMock extends AsyncClass {
     }
 
     // store agent (this will map agentId to transportId)
-    const succeeded = ref.mem.insert(agent)
-    // log.t('_track() succeeded? for "' + agentId + '" and DNA "' + dnaAddress + '" = ' + succeeded)
+    ref.mem.insert(agent)
 
     // send all 'get list' requests
     let requestId = this._createRequest(dnaAddress, agentId)

--- a/packages/n3h-mock/lib/index.js
+++ b/packages/n3h-mock/lib/index.js
@@ -22,7 +22,7 @@ class N3hMock extends AsyncClass {
 
     // Initialize members
     this._memory = {}
-    this._senders = {}
+    // this._senders = {}
     // this.senders_by_dna = {}
 
     this._publishedEntryBook = {}
@@ -90,6 +90,42 @@ class N3hMock extends AsyncClass {
   }
 
   /**
+   *  Check if agent is tracking dna.
+   *  If not, will try to send a FailureResult back to sender, if sender info is provided.
+   *  Returns true if agent is tracking dna.
+   */
+  _getTransportIdOrFail (dnaAddress, receiverAgentId, senderAgentId, requestId) {
+    // get memory slice
+    let ref = this._getMemRef(dnaAddress)
+    // Make sure receiver is known
+    if (ref.agentToTransportId.contains(receiverAgentId)) {
+      return ref.agentToTransportId[receiverAgentId]
+    }
+    log.e('#### Check failed for "' + receiverAgentId + '" for DNA "' + dnaAddress + '"')
+    // No receiver, try to return a failureResult back to sender
+    // Make sure sender is known
+    if (senderAgentId === undefined) {
+      log.e('#### No sender info provided')
+      return null
+    }
+    if (!ref.agentToTransportId.contains(senderAgentId)) {
+      log.e('Unknown sender "' + senderAgentId + '" for DNA "' + dnaAddress + '"')
+      return null
+    }
+    // Send FailureResult back to sender
+    const fromZmqId = ref.agentToTransportId[senderAgentId]
+    this._ipc.sendOne(fromZmqId, 'json', {
+      method: 'failureResult',
+      dnaAddress: dnaAddress,
+      _id: requestId,
+      toAgentId: senderAgentId,
+      errorInfo: 'No routing for agent id "' + receiverAgentId + '"'
+    })
+    // Done
+    return null
+  }
+
+  /**
    * Received 'message' from IPC: process it
    */
   _handleIpcMessage (opt) {
@@ -104,13 +140,18 @@ class N3hMock extends AsyncClass {
     if (opt.name === 'json' && typeof opt.data.method === 'string') {
       switch (opt.data.method) {
         case 'failureResult':
+          // Note: opt.data is a FailureResultData
           // Check if its a response to our own request
           bucketId = this._checkRequest(opt.data._id)
           if (bucketId !== '') {
             return
           }
-          // if not relay to receipient
-          this._ipc.send('json', opt.data)
+          // if not relay to receipient if possible
+          toZmqId = this._getTransportIdOrFail(opt.data.dnaAddress, opt.data.toAgentId)
+          if (toZmqId === null) {
+            return
+          }
+          this._ipc.sendOne(toZmqId, 'json', opt.data)
           return
         case 'requestState':
           this._ipc.send('json', {
@@ -131,21 +172,19 @@ class N3hMock extends AsyncClass {
         case 'trackDna':
           this._track(opt.data.dnaAddress, opt.data.agentId, opt.fromZmqId)
           return
-        case 'sendMessage':
-          this._getMemRef(opt.data.dnaAddress)
-
-          if (!(opt.data.toAgentId in this._senders)) {
-            this._ipc.send('json', {
-              method: 'failureResult',
-              dnaAddress: opt.data.dnaAddress,
-              _id: opt.data._id,
-              toAgentId: opt.data.fromAgentId,
-              errorInfo: 'No routing for agent id "' + opt.data.toAgentId + '" aborting send'
-            })
+        case 'untrackDna':
+          // if not relay to receipient if possible
+          toZmqId = this._getTransportIdOrFail(opt.data.dnaAddress, opt.data.agentId)
+          if (toZmqId === null) {
             return
           }
-
-          toZmqId = this._senders[opt.data.toAgentId]
+          this._untrack(opt.data.dnaAddress, opt.data.agentId, opt.fromZmqId)
+          return
+        case 'sendMessage':
+          toZmqId = this._getTransportIdOrFail(opt.data.dnaAddress, opt.data.toAgentId, opt.data.fromAgentId, opt.data._id)
+          if (toZmqId === null) {
+            return
+          }
           this._ipc.sendOne(toZmqId, 'json', {
             method: 'handleSendMessage',
             _id: opt.data._id,
@@ -156,25 +195,11 @@ class N3hMock extends AsyncClass {
           })
           return
         case 'handleSendMessageResult':
-          this._getMemRef(opt.data.dnaAddress)
-
-          if (!(opt.data.toAgentId in this._senders)) {
-            log.t('sendMessage failed: unknown target node: ' + opt.data.toAgentId)
+          // Note: opt.data is a MessageData
+          toZmqId = this._getTransportIdOrFail(opt.data.dnaAddress, opt.data.toAgentId, opt.data.fromAgentId, opt.data._id)
+          if (toZmqId === null) {
             return
           }
-          toZmqId = this._senders[opt.data.toAgentId]
-
-          if (!(opt.data.toAgentId in this._senders)) {
-            this._ipc.send('json', {
-              method: 'failureResult',
-              dnaAddress: opt.data.dnaAddress,
-              _id: opt.data._id,
-              toAgentId: opt.data.fromAgentId,
-              errorInfo: 'No routing for agent id "' + opt.data.toAgentId + '" aborting handleSendMessageResult'
-            })
-            return
-          }
-          toZmqId = this._senders[opt.data.toAgentId]
           this._ipc.sendOne(toZmqId, 'json', {
             method: 'sendMessageResult',
             _id: opt.data._id,
@@ -186,6 +211,10 @@ class N3hMock extends AsyncClass {
           return
         case 'publishEntry':
           // Note: opt.data is a EntryData
+          toZmqId = this._getTransportIdOrFail(opt.data.dnaAddress, opt.data.providerAgentId)
+          if (toZmqId === null) {
+            return
+          }
           // Bookkeep
           this._bookkeepAddress(
             this._publishedEntryBook,
@@ -203,6 +232,10 @@ class N3hMock extends AsyncClass {
           return
         case 'publishMeta':
           // Note: opt.data is a DhtMetaData
+          toZmqId = this._getTransportIdOrFail(opt.data.dnaAddress, opt.data.providerAgentId)
+          if (toZmqId === null) {
+            return
+          }
           // Bookkeep each metaId
           for (const metaContent of opt.data.contentList) {
             let metaId = this._intoMetaId(opt.data.entryAddress, opt.data.attribute, metaContent)
@@ -218,6 +251,11 @@ class N3hMock extends AsyncClass {
           })
           return
         case 'fetchEntry':
+          // Note: opt.data is a FetchEntryData
+          toZmqId = this._getTransportIdOrFail(opt.data.dnaAddress, opt.data.requesterAgentId)
+          if (toZmqId === null) {
+            return
+          }
           // erm... since we're fully connected,
           // just redirect this back to itself for now...
           opt.data.method = 'handleFetchEntry'
@@ -225,6 +263,10 @@ class N3hMock extends AsyncClass {
           return
         case 'handleFetchEntryResult':
           // Note: opt.data is a FetchEntryResultData
+          toZmqId = this._getTransportIdOrFail(opt.data.dnaAddress, opt.data.providerAgentId, opt.data.requesterAgentId, opt.data._id)
+          if (toZmqId === null) {
+            return
+          }
           // if this message is a response from our own request, do a publish
           if (opt.data._id in this._requestBook) {
             delete this._requestBook[opt.data._id]
@@ -246,6 +288,11 @@ class N3hMock extends AsyncClass {
           this._ipc.send('json', opt.data)
           return
         case 'fetchMeta':
+          // Note: opt.data is a FetchMetaData
+          toZmqId = this._getTransportIdOrFail(opt.data.dnaAddress, opt.data.requesterAgentId)
+          if (toZmqId === null) {
+            return
+          }
           // erm... since we're fully connected,
           // just redirect this back to itself for now...
           opt.data.method = 'handleFetchMeta'
@@ -253,6 +300,10 @@ class N3hMock extends AsyncClass {
           return
         case 'handleFetchMetaResult':
           // Note: opt.data is a FetchMetaResultData
+          toZmqId = this._getTransportIdOrFail(opt.data.dnaAddress, opt.data.providerAgentId, opt.data.requesterAgentId, opt.data._id)
+          if (toZmqId === null) {
+            return
+          }
           // if its from our own request, do a publish for each new/unknown meta content
           if (opt.data._id in this._requestBook) {
             bucketId = this._checkRequest(opt.data._id)
@@ -478,19 +529,42 @@ class N3hMock extends AsyncClass {
   /**
    *
    */
-  _track (dnaAddress, agentId, fromZmqId) {
+  _untrack (dnaAddress, agentId) {
+    // get mem slice
+    // const ref = this._getMemRef(dnaAddress)
+    // remove agent?
+    // delete ref.agentToTransportId.agentId
+
+    // get mem slice
     const ref = this._getMemRef(dnaAddress)
+    // create data entry
+    const agent = {
+      type: 'agent',
+      dnaAddress: dnaAddress,
+      agentId: agentId,
+      transportId: null
+    }
+
     // store agent (this will map agentId to transportId)
-    ref.mem.insert({
+    ref.mem.insert(agent)
+  }
+
+  /**
+   *
+   */
+  _track (dnaAddress, agentId, fromZmqId) {
+    // get mem slice
+    const ref = this._getMemRef(dnaAddress)
+    // create data entry
+    const agent = {
       type: 'agent',
       dnaAddress: dnaAddress,
       agentId: agentId,
       transportId: fromZmqId
-    })
-    // also map agentId to transportId with in _senders
-    // const bucketId = this._catDnaAgent(dnaAddress, agentId)
-    // log.t("tracking: '" + bucketId + "' for " + fromZmqId)
-    this._senders[agentId] = fromZmqId
+    }
+
+    // store agent (this will map agentId to transportId)
+    ref.mem.insert(agent)
 
     // send all 'get list' requests
     let requestId = this._createRequest(dnaAddress, agentId)

--- a/packages/n3h-mock/lib/index.js
+++ b/packages/n3h-mock/lib/index.js
@@ -22,8 +22,6 @@ class N3hMock extends AsyncClass {
 
     // Initialize members
     this._memory = {}
-    // this._senders = {}
-    // this.senders_by_dna = {}
 
     this._publishedEntryBook = {}
     this._storedEntryBook = {}
@@ -92,7 +90,7 @@ class N3hMock extends AsyncClass {
   /**
    *  Check if agent is tracking dna.
    *  If not, will try to send a FailureResult back to sender, if sender info is provided.
-   *  Returns true if agent is tracking dna.
+   *  Returns transportId of receiverAgentId if agent is tracking dna.
    */
   _getTransportIdOrFail (dnaAddress, receiverAgentId, senderAgentId, requestId) {
     // get memory slice
@@ -539,11 +537,6 @@ class N3hMock extends AsyncClass {
    *
    */
   _untrack (dnaAddress, agentId) {
-    // get mem slice
-    // const ref = this._getMemRef(dnaAddress)
-    // remove agent?
-    // delete ref.agentToTransportId.agentId
-
     // get mem slice
     const ref = this._getMemRef(dnaAddress)
     // create data entry

--- a/packages/n3h-mock/lib/index.js
+++ b/packages/n3h-mock/lib/index.js
@@ -96,14 +96,14 @@ class N3hMock extends AsyncClass {
     // get memory slice
     let ref = this._getMemRef(dnaAddress)
     // Make sure receiver is known
-    if (ref.agentToTransportId[receiverAgentId] !== undefined) {
+    if (ref.agentToTransportId[receiverAgentId]) {
       log.t('oooo CHECK OK for "' + receiverAgentId + '" for DNA "' + dnaAddress + '" = ' + ref.agentToTransportId[receiverAgentId])
       return ref.agentToTransportId[receiverAgentId]
     }
     log.e('#### Check failed for "' + receiverAgentId + '" for DNA "' + dnaAddress + '"')
     // No receiver, try to return a failureResult back to sender
     // Make sure sender is known
-    if (senderAgentId === undefined) {
+    if (!senderAgentId) {
       log.e('#### No sender info provided')
       return null
     }

--- a/packages/n3h-mock/lib/mem.js
+++ b/packages/n3h-mock/lib/mem.js
@@ -73,10 +73,10 @@ class Mem {
     if (!(entry.loc in this._data)) {
       this._data[entry.loc] = {}
     }
-    // check hash & loc integrity
-    if (entry.hash in this._data[entry.loc]) {
-      return false
-    }
+    // check if already have data in store
+    // if (entry.hash in this._data[entry.loc]) {
+    //   return false
+    // }
     // store entry
     this._data[entry.loc][entry.hash] = entry
     // index with each indexer by using its indexing function

--- a/packages/n3h-mock/lib/mem.js
+++ b/packages/n3h-mock/lib/mem.js
@@ -90,15 +90,6 @@ class Mem {
   /**
    *
    */
-  hasValue (data) {
-    const entry = getEntry(data)
-    return this.has(entry.hash)
-  }
-
-
-  /**
-   *
-   */
   has (hash) {
     const loc = getLoc(Buffer.from(hash, 'base64'))
     if (!(loc in this._data)) {

--- a/packages/n3h-mock/lib/mem.js
+++ b/packages/n3h-mock/lib/mem.js
@@ -89,6 +89,15 @@ class Mem {
   /**
    *
    */
+  hasValue (data) {
+    const entry = getEntry(data)
+    return this.has(entry.hash)
+  }
+
+
+  /**
+   *
+   */
   has (hash) {
     const loc = getLoc(Buffer.from(hash, 'base64'))
     if (!(loc in this._data)) {

--- a/packages/n3h-mock/lib/mem.js
+++ b/packages/n3h-mock/lib/mem.js
@@ -74,6 +74,7 @@ class Mem {
       this._data[entry.loc] = {}
     }
     // check if already have data in store
+    // HACK: Removed for re-tracking a DNA
     // if (entry.hash in this._data[entry.loc]) {
     //   return false
     // }


### PR DESCRIPTION
Handle "untrackDna" in mock and hackmode.
Now n3h will check that the DNA is tracked by the agent before processing IPC messages.
If DNA is not tracked, n3h will send back a "failureResult" message to IPC endpoint.