### PR TITLE
Fixed n3h-mock and sharing common code with Hackmode

### DIFF
--- a/packages/hackmode/lib/index.js
+++ b/packages/hackmode/lib/index.js
@@ -1,12 +1,14 @@
 const msgpack = require('msgpack-lite')
 
-const { AsyncClass } = require('@holochain/n3h-common')
+// const { AsyncClass } = require('@holochain/n3h-common')
 
-const { P2p, Connection } = require('@holochain/n3h-mod-spec')
+const { P2p } = require('@holochain/n3h-mod-spec')
 const { P2pBackendHackmodePeer } = require('./p2p-backend-hackmode-peer')
-const { ConnectionBackendWss } = require('@holochain/n3h-mod-connection-wss')
+// const { ConnectionBackendWss } = require('@holochain/n3h-mod-connection-wss')
 
-const config = require('./config')
+const { N3hMode } = require('../../n3h-ipc/lib/n3hMode')
+
+// const config = require('./config')
 
 const { Mem, getHash } = require('./mem')
 
@@ -40,86 +42,29 @@ const log = tweetlog('@hackmode@')
  * - `webproxy.wssAdvertise` {uri|"auto"} - Cannot be paired with `wssRelayPeers`. Sets up this node to be directly connectable at this address. Special case if set to `"auto"` will pick the first public NIC binding... allowing for os-assigned ports.
  * - `webproxy.wssRelayPeers` {array<uri>} - Cannot be paired with `wssAdvertise`. Uri array of relay peers to connect through. (currently you can only specify 1). Use this if behind a NAT, all messages will be routed through the peer specified here.
  */
-class N3hHackMode extends AsyncClass {
+class N3hHackMode extends N3hMode {
   async init (workDir, rawConfigData) {
     await super.init()
 
-    this._config = config(rawConfigData || {})
-    log.i('@@ CONFIG @@', JSON.stringify(this._config, null, 2))
-
-    this._memory = {}
     this._peerBook = {}
-
-    // Book: Array of entryAddress (or metaId) per dna
-    this._publishedEntryBook = {}
-    this._storedEntryBook = {}
-    this._publishedMetaBook = {}
-    this._storedMetaBook = {}
-
-    this._requestBook = new Map()
-    this._requestCount = 0
 
     this._gossipState = {
       lastPeerIndex: 0,
       pauseUntil: 0
     }
 
-    // Map of AgentId -> DNAs
-    // Can also serve as a list of known local agents
-    this._ipcDnaByAgent = new Map()
-
-    this._workDir = workDir
-
     await Promise.all([
-      this._initIpc(),
       this._initP2p()
     ])
 
     // make sure this is output despite our log settings
-    console.log('#IPC-BINDING#:' + this._ipcBoundUri)
     console.log('#P2P-BINDING#:' + this._p2p.getAdvertise())
-    console.log('#IPC-READY#')
+    console.log('#P2P-READY#')
 
     this._gossipTimer = setInterval(() => this._checkGossip(), 200)
   }
 
-  async run () {
-    log.t('running')
-  }
-
   // -- private -- //
-
-  /**
-   * @private
-   */
-  async _initIpc () {
-    this._ipc = await new Connection(ConnectionBackendWss, {
-      // TODO - allow some kind of environment var?? for setting passphrase
-      passphrase: 'hello',
-      rsaBits: this._config.ipc.connection.rsaBits,
-      bind: this._config.ipc.connection.bind
-    })
-    this._ipc.on('event', ev => this._handleIpcEvent(ev))
-    await Promise.all(this._config.ipc.connection.bind.map(
-      b => this._ipc.bind(b)))
-    log.t('bound to', this._ipcBoundUri)
-  }
-
-  /**
-   * @private
-   */
-  _ipcSend (type, data) {
-    switch (type) {
-      case 'json':
-        let msg = Buffer.from(JSON.stringify(data), 'utf8')
-        msg = msgpack.encode({ name: 'json', data: msg }).toString('base64')
-        // for now just sending to everything
-        this._ipc.send(Array.from(this._ipc.keys()), msg)
-        break
-      default:
-        throw new Error('unexpected ipc send type: ' + type)
-    }
-  }
 
   /**
    * @private
@@ -167,40 +112,6 @@ class N3hHackMode extends AsyncClass {
       this._peerBook[id] = {
         lastGossip: 0
       }
-    }
-  }
-
-  /**
-   * @private
-   */
-  _handleIpcEvent (ev) {
-    switch (ev.type) {
-      case 'bind':
-        if (!this._icpBoundUri) {
-          this._ipcBoundUri = ev.boundUriList[0]
-        }
-        break
-      case 'close':
-      case 'connection':
-        // we don't need to do anything here
-        break
-      case 'message':
-        const dataPre = msgpack.decode(Buffer.from(ev.buffer, 'base64'))
-        const name = dataPre.name.toString()
-        switch (name) {
-          case 'json':
-            const data = JSON.parse(dataPre.data.toString('utf8'))
-            if (typeof data.method !== 'string') {
-              throw new Error('bad json msg: ' + JSON.stringify(data))
-            }
-            this._handleIpcJson(data)
-            break
-          default:
-            throw new Error('unexpected msg type: ' + name)
-        }
-        break
-      default:
-        throw new Error('unexpected ipc event type: ' + JSON.stringify(ev))
     }
   }
 
@@ -919,113 +830,6 @@ class N3hHackMode extends AsyncClass {
       }
     }
     return this._memory[dnaAddress]
-  }
-
-  /**
-   * @private
-   */
-  _checkRequest (requestId) {
-    if (!this._requestBook.has(requestId)) {
-      return ''
-    }
-    let bucketId = this._requestBook.get(requestId)
-    this._requestBook.delete(requestId)
-    return bucketId
-  }
-
-  /**
-   * @private
-   */
-  _ipcHasTrack (agentId, dnaAddress) {
-    log.t('_ipcHasTrack:', agentId, dnaAddress)
-    if (!this._ipcDnaByAgent.has(agentId)) {
-      return false
-    }
-    const dnas = this._ipcDnaByAgent.get(agentId)
-    log.t('_ipcHasTrack()', dnas.has(dnaAddress))
-    return dnas.has(dnaAddress)
-  }
-
-  /**
-   * @private
-   */
-  _ipcAddTrack (agentId, dnaAddress) {
-    log.t('_ipcAddTrack:', agentId, dnaAddress)
-    let dnas
-    if (!this._ipcDnaByAgent.has(agentId)) {
-      dnas = new Set()
-    } else {
-      dnas = this._ipcDnaByAgent.get(agentId)
-    }
-    dnas.add(dnaAddress)
-    this._ipcDnaByAgent.set(agentId, dnas)
-  }
-
-  /**
-   * @private
-   */
-  _ipcRemoveTrack (agentId, dnaAddress) {
-    log.t('_ipcRemoveTrack:', agentId, dnaAddress)
-    let dnas
-    if (!this._ipcDnaByAgent.has(agentId)) {
-      return
-    }
-    dnas = this._ipcDnaByAgent.get(agentId)
-    dnas.delete(dnaAddress)
-    this._ipcDnaByAgent.set(agentId, dnas)
-  }
-
-  /**
-   *  Check if agent is tracking dna.
-   *  If not, will try to send a FailureResult back to IPC
-   *  Returns _ipcHasTrack() result
-   *  @private
-   */
-  _hasTrackOrFail (agentId, dnaAddress, requestId) {
-    // Check if receiver is known
-    if (this._ipcHasTrack(agentId, dnaAddress)) {
-      log.t('oooo HasTrack() CHECK OK for agent "' + agentId + '" -> DNA "' + dnaAddress + '"')
-      return true
-    }
-    // Send FailureResult back to IPC
-    log.e('#### HasTrack() CHECK FAILED for agent "' + agentId + '" -> DNA "' + dnaAddress + '"')
-    this._ipcSend('json', {
-      method: 'failureResult',
-      dnaAddress: dnaAddress,
-      _id: requestId,
-      toAgentId: agentId,
-      errorInfo: 'This agent is not tracking DNA "' + dnaAddress + '"'
-    })
-    // Done
-    return false
-  }
-
-
-  /**
-   *  Check if agent is tracking dna.
-   *  If not, will try to send a FailureResult back to sender (if sender info is provided).
-   *  Returns transportId of receiverAgentId if agent is tracking dna.
-   *  @private
-   */
-  _getTransportIdOrFail (dnaAddress, receiverAgentId, senderAgentId, requestId) {
-    // get memory slice
-    let ref = this._getMemRef(dnaAddress)
-    // Check if receiver is known
-    if (ref.agentToTransportId[receiverAgentId]) {
-      log.t('oooo CHECK OK for "' + receiverAgentId + '" for DNA "' + dnaAddress + '" = ' + ref.agentToTransportId[receiverAgentId])
-      return ref.agentToTransportId[receiverAgentId]
-    }
-    // Send FailureResult back to IPC, should be senderAgentId
-    log.e('#### Check failed for "' + receiverAgentId + '" for DNA "' + dnaAddress + '"')
-    this._ipcSend('json', {
-      method: 'failureResult',
-      dnaAddress: dnaAddress,
-      _id: requestId,
-      toAgentId: senderAgentId,
-      errorInfo: 'No routing for agent id "' + receiverAgentId + '"'
-    })
-    // Done
-    return null
   }
 
   /**

--- a/packages/hackmode/lib/index.js
+++ b/packages/hackmode/lib/index.js
@@ -64,7 +64,8 @@ class N3hHackMode extends AsyncClass {
       pauseUntil: 0
     }
 
-    // list of known local agents
+    // Map of AgentId -> DNAs
+    // Can also serve as a list of known local agents
     this._ipcDnaByAgent = new Map()
 
     this._workDir = workDir

--- a/packages/hackmode/lib/index.js
+++ b/packages/hackmode/lib/index.js
@@ -114,7 +114,7 @@ class N3hHackMode extends N3hMode {
   /**
    * @private
    */
-  _handleIpcJson (data, uri) {
+  _handleIpcJson (data) {
     log.t('Received IPC: ', data)
 
     let ref

--- a/packages/hackmode/lib/index.js
+++ b/packages/hackmode/lib/index.js
@@ -1,14 +1,9 @@
 const msgpack = require('msgpack-lite')
 
-// const { AsyncClass } = require('@holochain/n3h-common')
-
 const { P2p } = require('@holochain/n3h-mod-spec')
 const { P2pBackendHackmodePeer } = require('./p2p-backend-hackmode-peer')
-// const { ConnectionBackendWss } = require('@holochain/n3h-mod-connection-wss')
 
 const { N3hMode } = require('../../n3h-ipc/lib/n3hMode')
-
-// const config = require('./config')
 
 const { Mem, getHash } = require('./mem')
 
@@ -47,6 +42,7 @@ class N3hHackMode extends N3hMode {
     await super.init()
 
     this._peerBook = {}
+    this._requestBook = new Map()
 
     this._gossipState = {
       lastPeerIndex: 0,
@@ -118,7 +114,7 @@ class N3hHackMode extends N3hMode {
   /**
    * @private
    */
-  _handleIpcJson (data) {
+  _handleIpcJson (data, uri) {
     log.t('Received IPC: ', data)
 
     let ref
@@ -492,6 +488,18 @@ class N3hHackMode extends N3hMode {
     }
 
     throw new Error('unexpected input ' + JSON.stringify(data))
+  }
+
+  /**
+   * @private
+   */
+  _checkRequest (requestId) {
+    if (!this._requestBook.has(requestId)) {
+      return ''
+    }
+    let bucketId = this._requestBook.get(requestId)
+    this._requestBook.delete(requestId)
+    return bucketId
   }
 
   /**

--- a/packages/hackmode/lib/index.js
+++ b/packages/hackmode/lib/index.js
@@ -114,7 +114,7 @@ class N3hHackMode extends N3hMode {
   /**
    * @private
    */
-  _handleIpcJson (data) {
+  _handleIpcJson (data, senderId) {
     log.t('Received IPC: ', data)
 
     let ref

--- a/packages/hackmode/lib/p2p-backend-hackmode-peer.js
+++ b/packages/hackmode/lib/p2p-backend-hackmode-peer.js
@@ -299,8 +299,6 @@ class P2pBackendHackmodePeer extends AsyncClass {
         e.boundUriList.forEach(b => this._addBinding(b))
         break
       case 'connection':
-        await this._addConnection(e.id)
-        break
       case 'connect':
         await this._addConnection(e.id)
         break

--- a/packages/n3h-ipc/lib/n3hMode.js
+++ b/packages/n3h-ipc/lib/n3hMode.js
@@ -130,7 +130,7 @@ class N3hMode extends AsyncClass {
             if (typeof data.method !== 'string') {
               throw new Error('bad json msg: ' + JSON.stringify(data))
             }
-            this._handleIpcJson(data, ev.boundUriList[0])
+            this._handleIpcJson(data)
             break
           default:
             throw new Error('unexpected msg type: ' + name)

--- a/packages/n3h-ipc/lib/n3hMode.js
+++ b/packages/n3h-ipc/lib/n3hMode.js
@@ -1,0 +1,252 @@
+const msgpack = require('msgpack-lite')
+
+const { AsyncClass } = require('../../n3h-common/lib/index')
+
+const { Connection } = require('../../n3h-mod-spec/lib/index')
+const { ConnectionBackendWss } = require('../../n3h-mod-connection-wss/lib/index')
+
+const config = require('../../hackmode/lib/config')
+
+// const { Mem, getHash } = require('./mem')
+
+const tweetlog = require('../../tweetlog/lib/tweetlog')
+const log = tweetlog('@n3hMode@')
+
+/**
+ * N3h "hackmode" prototyping code
+ *
+ * Expects a config either over stdin or as a file `n3h-config.json` in the
+ * working directory.
+ * If neither is supplied, will load up the following default:
+ *
+ * ```
+ * "webproxy": {
+ *   "connection": {
+ *     "rsaBits": 1024,
+ *     "bind": [
+ *       "wss://0.0.0.0:0/"
+ *     ]
+ *   },
+ *   "wssAdvertise": "auto",
+ *   "wssRelayPeers": null
+ * }
+ * ```
+ *
+ * Config Definitions:
+ *
+ * - `webproxy.connection.rsaBits` {number} - rsa bits to use for tls on websocket server
+ * - `webproxy.connection.bind` {array<uri>} - uri array of NICs to bind the websocket server. use host `0.0.0.0` for "all" NICs, use port `0` for random (os-assigned) port. You can specify a path, e.g. `"wss://127.0.0.1:8443/test/path/"`
+ * - `webproxy.wssAdvertise` {uri|"auto"} - Cannot be paired with `wssRelayPeers`. Sets up this node to be directly connectable at this address. Special case if set to `"auto"` will pick the first public NIC binding... allowing for os-assigned ports.
+ * - `webproxy.wssRelayPeers` {array<uri>} - Cannot be paired with `wssAdvertise`. Uri array of relay peers to connect through. (currently you can only specify 1). Use this if behind a NAT, all messages will be routed through the peer specified here.
+ */
+class N3hMode extends AsyncClass {
+  async init (workDir, rawConfigData) {
+    await super.init()
+
+    this._config = config(rawConfigData || {})
+    log.i('@@ CONFIG @@', JSON.stringify(this._config, null, 2))
+
+    this._memory = {}
+
+    // Book: Array of entryAddress (or metaId) per dna
+    this._publishedEntryBook = {}
+    this._storedEntryBook = {}
+    this._publishedMetaBook = {}
+    this._storedMetaBook = {}
+
+    this._requestBook = new Map()
+    this._requestCount = 0
+
+    // Map of AgentId -> DNAs
+    // Can also serve as a list of known local agents
+    this._ipcDnaByAgent = new Map()
+
+    this._workDir = workDir
+
+    await Promise.all([this._initIpc()])
+
+    // make sure this is output despite our log settings
+    console.log('#IPC-BINDING#:' + this._ipcBoundUri)
+    console.log('#IPC-READY#')
+  }
+
+  //
+  async run () {
+    log.t('running')
+  }
+
+  // -- private -- //
+
+  /**
+   * @private
+   */
+  async _initIpc () {
+    this._ipc = await new Connection(ConnectionBackendWss, {
+      // TODO - allow some kind of environment var?? for setting passphrase
+      passphrase: 'hello',
+      rsaBits: this._config.ipc.connection.rsaBits,
+      bind: this._config.ipc.connection.bind
+    })
+    this._ipc.on('event', ev => this._handleIpcEvent(ev))
+    await Promise.all(this._config.ipc.connection.bind.map(b => this._ipc.bind(b)))
+    log.t('bound to', this._ipcBoundUri)
+  }
+
+  /**
+   * @private
+   */
+  _ipcSend (type, data) {
+    switch (type) {
+      case 'json':
+        let msg = Buffer.from(JSON.stringify(data), 'utf8')
+        msg = msgpack.encode({name: 'json', data: msg}).toString('base64')
+        // for now just sending to everything
+        this._ipc.send(Array.from(this._ipc.keys()), msg)
+        break
+      default:
+        throw new Error('unexpected ipc send type: ' + type)
+    }
+  }
+
+  /**
+   * @private
+   */
+  _handleIpcEvent (ev) {
+    switch (ev.type) {
+      case 'bind':
+        if (!this._icpBoundUri) {
+          this._ipcBoundUri = ev.boundUriList[0]
+        }
+        break
+      case 'close':
+      case 'connection':
+        // we don't need to do anything here
+        break
+      case 'message':
+        const dataPre = msgpack.decode(Buffer.from(ev.buffer, 'base64'))
+        const name = dataPre.name.toString()
+        switch (name) {
+          case 'json':
+            const data = JSON.parse(dataPre.data.toString('utf8'))
+            if (typeof data.method !== 'string') {
+              throw new Error('bad json msg: ' + JSON.stringify(data))
+            }
+            this._handleIpcJson(data)
+            break
+          default:
+            throw new Error('unexpected msg type: ' + name)
+        }
+        break
+      default:
+        throw new Error('unexpected ipc event type: ' + JSON.stringify(ev))
+    }
+  }
+
+  /**
+   * @private
+   */
+  _checkRequest (requestId) {
+    if (!this._requestBook.has(requestId)) {
+      return ''
+    }
+    let bucketId = this._requestBook.get(requestId)
+    this._requestBook.delete(requestId)
+    return bucketId
+  }
+
+  /**
+   * @private
+   */
+  _ipcHasTrack (agentId, dnaAddress) {
+    log.t('_ipcHasTrack:', agentId, dnaAddress)
+    if (!this._ipcDnaByAgent.has(agentId)) {
+      return false
+    }
+    const dnas = this._ipcDnaByAgent.get(agentId)
+    log.t('_ipcHasTrack()', dnas.has(dnaAddress))
+    return dnas.has(dnaAddress)
+  }
+
+  /**
+   * @private
+   */
+  _ipcAddTrack (agentId, dnaAddress) {
+    log.t('_ipcAddTrack:', agentId, dnaAddress)
+    let dnas
+    if (!this._ipcDnaByAgent.has(agentId)) {
+      dnas = new Set()
+    } else {
+      dnas = this._ipcDnaByAgent.get(agentId)
+    }
+    dnas.add(dnaAddress)
+    this._ipcDnaByAgent.set(agentId, dnas)
+  }
+
+  /**
+   * @private
+   */
+  _ipcRemoveTrack (agentId, dnaAddress) {
+    log.t('_ipcRemoveTrack:', agentId, dnaAddress)
+    let dnas
+    if (!this._ipcDnaByAgent.has(agentId)) {
+      return
+    }
+    dnas = this._ipcDnaByAgent.get(agentId)
+    dnas.delete(dnaAddress)
+    this._ipcDnaByAgent.set(agentId, dnas)
+  }
+
+  /**
+   *  Check if agent is tracking dna.
+   *  If not, will try to send a FailureResult back to IPC
+   *  Returns _ipcHasTrack() result
+   *  @private
+   */
+  _hasTrackOrFail (agentId, dnaAddress, requestId) {
+    // Check if receiver is known
+    if (this._ipcHasTrack(agentId, dnaAddress)) {
+      log.t('oooo HasTrack() CHECK OK for agent "' + agentId + '" -> DNA "' + dnaAddress + '"')
+      return true
+    }
+    // Send FailureResult back to IPC
+    log.e('#### HasTrack() CHECK FAILED for agent "' + agentId + '" -> DNA "' + dnaAddress + '"')
+    this._ipcSend('json', {
+      method: 'failureResult',
+      dnaAddress: dnaAddress,
+      _id: requestId,
+      toAgentId: agentId,
+      errorInfo: 'This agent is not tracking DNA "' + dnaAddress + '"'
+    })
+    // Done
+    return false
+  }
+
+  /**
+   *  Check if agent is tracking dna.
+   *  If not, will try to send a FailureResult back to sender (if sender info is provided).
+   *  Returns transportId of receiverAgentId if agent is tracking dna.
+   *  @private
+   */
+  _getTransportIdOrFail (dnaAddress, receiverAgentId, senderAgentId, requestId) {
+    // get memory slice
+    let ref = this._getMemRef(dnaAddress)
+    // Check if receiver is known
+    if (ref.agentToTransportId[receiverAgentId]) {
+      log.t('oooo CHECK OK for "' + receiverAgentId + '" for DNA "' + dnaAddress + '" = ' + ref.agentToTransportId[receiverAgentId])
+      return ref.agentToTransportId[receiverAgentId]
+    }
+    // Send FailureResult back to IPC, should be senderAgentId
+    log.e('#### Check failed for "' + receiverAgentId + '" for DNA "' + dnaAddress + '"')
+    this._ipcSend('json', {
+      method: 'failureResult',
+      dnaAddress: dnaAddress,
+      _id: requestId,
+      toAgentId: senderAgentId,
+      errorInfo: 'No routing for agent id "' + receiverAgentId + '"'
+    })
+    // Done
+    return null
+  }
+}
+
+exports.N3hMode = N3hMode

--- a/packages/n3h-ipc/lib/n3hMode.js
+++ b/packages/n3h-ipc/lib/n3hMode.js
@@ -98,7 +98,6 @@ class N3hMode extends AsyncClass {
         log.t('_ipcSendOne', data)
         let msg = Buffer.from(JSON.stringify(data), 'utf8')
         msg = msgpack.encode({ name: 'json', data: msg }).toString('base64')
-        // for now just sending to everything
         this._ipc.send([key], msg)
         break
       default:

--- a/packages/n3h-mock/lib/index.js
+++ b/packages/n3h-mock/lib/index.js
@@ -28,7 +28,7 @@ class N3hMock extends N3hMode {
   /**
    * Received 'message' from IPC: process it
    */
-  _handleIpcJson (data, uri) {
+  _handleIpcJson (data) {
     log.t('Received IPC: ', data)
 
     let tId
@@ -65,7 +65,7 @@ class N3hMock extends N3hMode {
 
         return
       case 'trackDna':
-        this._track(data.dnaAddress, data.agentId, uri)
+        this._track(data.dnaAddress, data.agentId)
         return
       case 'untrackDna':
         // if not relay to receipient if possible
@@ -447,7 +447,7 @@ class N3hMock extends N3hMode {
   /**
    *
    */
-  _track (dnaAddress, agentId, fromTransportId) {
+  _track (dnaAddress, agentId) {
     // get mem slice
     const ref = this._getMemRef(dnaAddress)
     // create data entry
@@ -455,7 +455,7 @@ class N3hMock extends N3hMode {
       type: 'agent',
       dnaAddress: dnaAddress,
       agentId: agentId,
-      transportId: fromTransportId
+      transportId: this._ipcBoundUriList.values().next().value
     }
 
     // store agent (this will map agentId to transportId)

--- a/packages/n3h-mock/lib/index.js
+++ b/packages/n3h-mock/lib/index.js
@@ -1,8 +1,5 @@
-const path = require('path')
-const os = require('os')
-const { URL } = require('url')
 
-const { AsyncClass, mkdirp } = require('@holochain/n3h-common')
+const { N3hMode } = require('../../n3h-ipc/lib/n3hMode')
 const { IpcServer } = require('@holochain/n3h-ipc')
 
 const { Mem } = require('./mem')
@@ -10,7 +7,7 @@ const { Mem } = require('./mem')
 const tweetlog = require('@holochain/tweetlog')
 const log = tweetlog('@mock@')
 
-class N3hMock extends AsyncClass {
+class N3hMock extends N3hMode {
   /**
    * Network mock init.
    * Normally spawned by holochain_net where config is passed via environment variables
@@ -18,40 +15,10 @@ class N3hMock extends AsyncClass {
   async init (workDir, rawConfigData) {
     await super.init()
 
-    log.t('Initializing...')
+    this._requestBook = {}
 
     // Initialize members
-    this._memory = {}
-
-    this._publishedEntryBook = {}
-    this._storedEntryBook = {}
-    this._publishedMetaBook = {}
-    this._storedMetaBook = {}
-
-    this._requestBook = {}
-    this._requestCount = 0
-
     this._transferedRequestList = []
-
-    // Set working directory from config (a temp folder) or default to $home/.n3h
-    this._workDir = workDir
-
-    // Init "submodules"
-    await Promise.all([
-      this._initIpc()
-    ])
-
-    // Notify that Init is done
-    // make sure this is output despite our log settings
-    console.log('#IPC-BINDING#:' + this._ipcBoundUri)
-    console.log('#IPC-READY#')
-  }
-
-  /**
-   *
-   */
-  async run () {
-    log.t('running')
   }
 
   // ----------------------------------------------------------------------------------------------
@@ -59,401 +26,340 @@ class N3hMock extends AsyncClass {
   // ----------------------------------------------------------------------------------------------
 
   /**
-   * Set IPC function pointers on message received
-   */
-  async _initIpc () {
-    this._ipc = await new IpcServer()
-
-    this._ipc.on('clientAdd', id => {
-      log.t('clientAdd', id)
-    })
-    this._ipc.on('clientRemove', id => {
-      log.t('clientAdd', id)
-    })
-    this._ipc.on('message', opt => this._handleIpcMessage(opt))
-    this._ipc.boundEndpoint = (await this._ipc.bind(this._ipcUri))[0]
-
-    log.t('bound to', this._ipc.boundEndpoint)
-  }
-
-  /**
-   *  Check if agent is tracking dna.
-   *  If not, will try to send a FailureResult back to sender, if sender info is provided.
-   *  Returns transportId of receiverAgentId if agent is tracking dna.
-   */
-  _getTransportIdOrFail (dnaAddress, receiverAgentId, senderAgentId, requestId) {
-    // get memory slice
-    let ref = this._getMemRef(dnaAddress)
-    // Make sure receiver is known
-    if (ref.agentToTransportId[receiverAgentId]) {
-      log.t('oooo CHECK OK for "' + receiverAgentId + '" for DNA "' + dnaAddress + '" = ' + ref.agentToTransportId[receiverAgentId])
-      return ref.agentToTransportId[receiverAgentId]
-    }
-    log.e('#### Check failed for "' + receiverAgentId + '" for DNA "' + dnaAddress + '"')
-    // No receiver, try to return a failureResult back to sender
-    // Make sure sender is known
-    if (!senderAgentId) {
-      log.e('#### No sender info provided')
-      return null
-    }
-    if (ref.agentToTransportId[senderAgentId] === undefined) {
-      log.e('Unknown sender "' + senderAgentId + '" for DNA "' + dnaAddress + '"')
-      return null
-    }
-    // Send FailureResult back to sender
-    const fromTransportId = ref.agentToTransportId[senderAgentId]
-    this._ipc.sendOne(fromTransportId, 'json', {
-      method: 'failureResult',
-      dnaAddress: dnaAddress,
-      _id: requestId,
-      toAgentId: senderAgentId,
-      errorInfo: 'No routing for agent id "' + receiverAgentId + '"'
-    })
-    // Done
-    return null
-  }
-
-  /**
    * Received 'message' from IPC: process it
    */
-  _handleIpcMessage (opt) {
-    if (opt.name === 'ping' || opt.name === 'pong') {
-      return
-    }
-
-    log.t('Received IPC: ', opt)
+  _handleIpcJson (data, uri) {
+    log.t('Received IPC: ', data)
 
     let tId
     let bucketId
-    if (opt.name === 'json' && typeof opt.data.method === 'string') {
-      switch (opt.data.method) {
-        case 'failureResult':
-          // Note: opt.data is a FailureResultData
-          // Check if its a response to our own request
-          bucketId = this._checkRequest(opt.data._id)
-          if (bucketId !== '') {
-            return
-          }
-          // if not relay to receipient if possible
-          tId = this._getTransportIdOrFail(opt.data.dnaAddress, opt.data.toAgentId)
-          if (tId === null) {
-            return
-          }
-          this._ipc.sendOne(tId, 'json', opt.data)
+    switch (data.method) {
+      case 'failureResult':
+        // Note: data is a FailureResultData
+        // Check if its a response to our own request
+        bucketId = this._checkRequest(data._id)
+        if (bucketId !== '') {
           return
-        case 'requestState':
-          this._ipc.send('json', {
-            method: 'state',
-            state: 'ready',
-            id: '42', // not needed in mock mode
-            bindings: [] // not needed in mock mode
-          })
+        }
+        // if not relay to receipient if possible
+        tId = this._getTransportIdOrFail(data.dnaAddress, data.toAgentId)
+        if (tId === null) {
           return
-        case 'connect':
-          // maybe log an error?
-          this._ipc.send('json', {
-            method: 'peerConnected',
-            agentId: opt.data.address
-          })
+        }
+        this._ipc.sendOne(tId, 'json', data)
+        return
+      case 'requestState':
+        this._ipc.send('json', {
+          method: 'state',
+          state: 'ready',
+          id: '42', // not needed in mock mode
+          bindings: [] // not needed in mock mode
+        })
+        return
+      case 'connect':
+        // maybe log an error?
+        this._ipc.send('json', {
+          method: 'peerConnected',
+          agentId: data.address
+        })
 
+        return
+      case 'trackDna':
+        this._track(data.dnaAddress, data.agentId, uri)
+        return
+      case 'untrackDna':
+        // if not relay to receipient if possible
+        tId = this._getTransportIdOrFail(data.dnaAddress, data.agentId)
+        if (tId === null) {
           return
-        case 'trackDna':
-          this._track(opt.data.dnaAddress, opt.data.agentId, opt.fromZmqId)
+        }
+        this._untrack(data.dnaAddress, data.agentId)
+        return
+      case 'sendMessage':
+        tId = this._getTransportIdOrFail(data.dnaAddress, data.fromAgentId, data.fromAgentId, data._id)
+        if (tId === null) {
           return
-        case 'untrackDna':
-          // if not relay to receipient if possible
-          tId = this._getTransportIdOrFail(opt.data.dnaAddress, opt.data.agentId)
-          if (tId === null) {
-            return
-          }
-          this._untrack(opt.data.dnaAddress, opt.data.agentId, opt.fromZmqId)
+        }
+        tId = this._getTransportIdOrFail(data.dnaAddress, data.toAgentId, data.fromAgentId, data._id)
+        if (tId === null) {
           return
-        case 'sendMessage':
-          tId = this._getTransportIdOrFail(opt.data.dnaAddress, opt.data.fromAgentId, opt.data.fromAgentId, opt.data._id)
-          if (tId === null) {
-            return
-          }
-          tId = this._getTransportIdOrFail(opt.data.dnaAddress, opt.data.toAgentId, opt.data.fromAgentId, opt.data._id)
-          if (tId === null) {
-            return
-          }
-          this._ipc.sendOne(tId, 'json', {
-            method: 'handleSendMessage',
-            _id: opt.data._id,
-            dnaAddress: opt.data.dnaAddress,
-            toAgentId: opt.data.toAgentId,
-            fromAgentId: opt.data.fromAgentId,
-            data: opt.data.data
-          })
+        }
+        this._ipc.sendOne(tId, 'json', {
+          method: 'handleSendMessage',
+          _id: data._id,
+          dnaAddress: data.dnaAddress,
+          toAgentId: data.toAgentId,
+          fromAgentId: data.fromAgentId,
+          data: data.data
+        })
+        return
+      case 'handleSendMessageResult':
+        // Note: data is a MessageData
+        tId = this._getTransportIdOrFail(data.dnaAddress, data.fromAgentId, data.fromAgentId, data._id)
+        if (tId === null) {
           return
-        case 'handleSendMessageResult':
-          // Note: opt.data is a MessageData
-          tId = this._getTransportIdOrFail(opt.data.dnaAddress, opt.data.fromAgentId, opt.data.fromAgentId, opt.data._id)
-          if (tId === null) {
-            return
-          }
-          tId = this._getTransportIdOrFail(opt.data.dnaAddress, opt.data.toAgentId, opt.data.fromAgentId, opt.data._id)
-          if (tId === null) {
-            return
-          }
-          this._ipc.sendOne(tId, 'json', {
-            method: 'sendMessageResult',
-            _id: opt.data._id,
-            dnaAddress: opt.data.dnaAddress,
-            toAgentId: opt.data.toAgentId,
-            fromAgentId: opt.data.fromAgentId,
-            data: opt.data.data
-          })
+        }
+        tId = this._getTransportIdOrFail(data.dnaAddress, data.toAgentId, data.fromAgentId, data._id)
+        if (tId === null) {
           return
-        case 'publishEntry':
-          // Note: opt.data is a EntryData
-          tId = this._getTransportIdOrFail(opt.data.dnaAddress, opt.data.providerAgentId)
-          if (tId === null) {
-            return
-          }
-          // Bookkeep
-          this._bookkeepAddress(
-            this._publishedEntryBook,
-            opt.data.dnaAddress,
-            opt.data.providerAgentId,
-            opt.data.address
-          )
-          // TODO: we don't actually need to store the data on the nodejs side, we could just make all the store requests to connected nodes inline here, but that could be an optimization for later.
-          this._getMemRef(opt.data.dnaAddress).mem.insert({
+        }
+        this._ipc.sendOne(tId, 'json', {
+          method: 'sendMessageResult',
+          _id: data._id,
+          dnaAddress: data.dnaAddress,
+          toAgentId: data.toAgentId,
+          fromAgentId: data.fromAgentId,
+          data: data.data
+        })
+        return
+      case 'publishEntry':
+        // Note: data is a EntryData
+        tId = this._getTransportIdOrFail(data.dnaAddress, data.providerAgentId)
+        if (tId === null) {
+          return
+        }
+        // Bookkeep
+        this._bookkeepAddress(
+          this._publishedEntryBook,
+          data.dnaAddress,
+          data.providerAgentId,
+          data.address
+        )
+        // TODO: we don't actually need to store the data on the nodejs side, we could just make all the store requests to connected nodes inline here, but that could be an optimization for later.
+        this._getMemRef(data.dnaAddress).mem.insert({
+          type: 'dhtEntry',
+          providerAgentId: data.providerAgentId,
+          address: data.address,
+          content: data.content
+        })
+        return
+      case 'publishMeta':
+        // Note: opt.data is a DhtMetaData
+        tId = this._getTransportIdOrFail(data.dnaAddress, data.providerAgentId)
+        if (tId === null) {
+          return
+        }
+        // Bookkeep each metaId
+        for (const metaContent of data.contentList) {
+          let metaId = this._intoMetaId(data.entryAddress, data.attribute, metaContent)
+          this._bookkeepAddress(this._publishedMetaBook, data.dnaAddress, data.providerAgentId, metaId)
+        }
+        // Store on all nodes
+        this._getMemRef(data.dnaAddress).mem.insert({
+          type: 'dhtMeta',
+          providerAgentId: data.providerAgentId,
+          entryAddress: data.entryAddress,
+          attribute: data.attribute,
+          contentList: data.contentList
+        })
+        return
+      case 'fetchEntry':
+        // Note: data is a FetchEntryData
+        tId = this._getTransportIdOrFail(data.dnaAddress, data.requesterAgentId)
+        if (tId === null) {
+          return
+        }
+        // erm... since we're fully connected,
+        // just redirect this back to itself for now...
+        data.method = 'handleFetchEntry'
+        this._ipc.send('json', data)
+        return
+      case 'handleFetchEntryResult':
+        // Note: data is a FetchEntryResultData
+        tId = this._getTransportIdOrFail(data.dnaAddress, data.providerAgentId, data.requesterAgentId, data._id)
+        if (tId === null) {
+          return
+        }
+        // if this message is a response from our own request, do a publish
+        if (data._id in this._requestBook) {
+          delete this._requestBook[data._id]
+          this._getMemRef(data.dnaAddress).mem.insert({
             type: 'dhtEntry',
-            providerAgentId: opt.data.providerAgentId,
-            address: opt.data.address,
-            content: opt.data.content
+            providerAgentId: data.providerAgentId,
+            entryAddress: data.address,
+            content: data.content
           })
           return
-        case 'publishMeta':
-          // Note: opt.data is a DhtMetaData
-          tId = this._getTransportIdOrFail(opt.data.dnaAddress, opt.data.providerAgentId)
-          if (tId === null) {
-            return
-          }
-          // Bookkeep each metaId
-          for (const metaContent of opt.data.contentList) {
-            let metaId = this._intoMetaId(opt.data.entryAddress, opt.data.attribute, metaContent)
-            this._bookkeepAddress(this._publishedMetaBook, opt.data.dnaAddress, opt.data.providerAgentId, metaId)
-          }
-          // Store on all nodes
-          this._getMemRef(opt.data.dnaAddress).mem.insert({
-            type: 'dhtMeta',
-            providerAgentId: opt.data.providerAgentId,
-            entryAddress: opt.data.entryAddress,
-            attribute: opt.data.attribute,
-            contentList: opt.data.contentList
-          })
+        }
+        // otherwise since we're fully connected, just redirect this back to itself for now...
+        // Transfer this id only once
+        if (this._transferedRequestList.includes(data._id)) {
           return
-        case 'fetchEntry':
-          // Note: opt.data is a FetchEntryData
-          tId = this._getTransportIdOrFail(opt.data.dnaAddress, opt.data.requesterAgentId)
-          if (tId === null) {
-            return
-          }
-          // erm... since we're fully connected,
-          // just redirect this back to itself for now...
-          opt.data.method = 'handleFetchEntry'
-          this._ipc.send('json', opt.data)
+        }
+        this._transferedRequestList.push(data._id)
+        data.method = 'fetchEntryResult'
+        this._ipc.send('json', data)
+        return
+      case 'fetchMeta':
+        // Note: data is a FetchMetaData
+        tId = this._getTransportIdOrFail(data.dnaAddress, data.requesterAgentId)
+        if (tId === null) {
           return
-        case 'handleFetchEntryResult':
-          // Note: opt.data is a FetchEntryResultData
-          tId = this._getTransportIdOrFail(opt.data.dnaAddress, opt.data.providerAgentId, opt.data.requesterAgentId, opt.data._id)
-          if (tId === null) {
-            return
-          }
-          // if this message is a response from our own request, do a publish
-          if (opt.data._id in this._requestBook) {
-            delete this._requestBook[opt.data._id]
-            this._getMemRef(opt.data.dnaAddress).mem.insert({
-              type: 'dhtEntry',
-              providerAgentId: opt.data.providerAgentId,
-              entryAddress: opt.data.address,
-              content: opt.data.content
-            })
-            return
-          }
-          // otherwise since we're fully connected, just redirect this back to itself for now...
-          // Transfer this id only once
-          if (this._transferedRequestList.includes(opt.data._id)) {
-            return
-          }
-          this._transferedRequestList.push(opt.data._id)
-          opt.data.method = 'fetchEntryResult'
-          this._ipc.send('json', opt.data)
+        }
+        // erm... since we're fully connected,
+        // just redirect this back to itself for now...
+        data.method = 'handleFetchMeta'
+        this._ipc.send('json', data)
+        return
+      case 'handleFetchMetaResult':
+        // Note: data is a FetchMetaResultData
+        tId = this._getTransportIdOrFail(data.dnaAddress, data.providerAgentId, data.requesterAgentId, data._id)
+        if (tId === null) {
           return
-        case 'fetchMeta':
-          // Note: opt.data is a FetchMetaData
-          tId = this._getTransportIdOrFail(opt.data.dnaAddress, opt.data.requesterAgentId)
-          if (tId === null) {
-            return
-          }
-          // erm... since we're fully connected,
-          // just redirect this back to itself for now...
-          opt.data.method = 'handleFetchMeta'
-          this._ipc.send('json', opt.data)
-          return
-        case 'handleFetchMetaResult':
-          // Note: opt.data is a FetchMetaResultData
-          tId = this._getTransportIdOrFail(opt.data.dnaAddress, opt.data.providerAgentId, opt.data.requesterAgentId, opt.data._id)
-          if (tId === null) {
-            return
-          }
-          // if its from our own request, do a publish for each new/unknown meta content
-          if (opt.data._id in this._requestBook) {
-            bucketId = this._checkRequest(opt.data._id)
-            if (bucketId === '') {
-              return
-            }
-            log.t('Handle our handleFetchMetaResult:', opt.data._id, bucketId)
-            // get already known publishing list
-            let knownPublishingMetaList = []
-            if (bucketId in this._publishedMetaBook) {
-              knownPublishingMetaList = this._publishedMetaBook[bucketId]
-            }
-            for (const metaContent of opt.data.contentList) {
-              let metaId = this._intoMetaId(opt.data.entryAddress, opt.data.attribute, metaContent)
-              if (knownPublishingMetaList.includes(metaId)) {
-                continue
-              }
-              this._getMemRef(opt.data.dnaAddress).mem.insert({
-                type: 'dhtMeta',
-                providerAgentId: opt.data.providerAgentId,
-                entryAddress: opt.data.entryAddress,
-                attribute: opt.data.attribute,
-                contentList: [metaContent]
-              })
-            }
-            return
-          }
-          // otherwise since we're fully connected, just redirect this back to itself for now..
-          // Transfer this id only once
-          if (this._transferedRequestList.includes(opt.data._id)) {
-            return
-          }
-          this._transferedRequestList.push(opt.data._id)
-          log.t('Transfer handleFetchMetaResult as fetchMetaResult:', opt.data._id)
-          opt.data.method = 'fetchMetaResult'
-          this._ipc.send('json', opt.data)
-          return
-
-        case 'handleGetPublishingEntryListResult':
-          // Note: opt.data is EntryListData
-          // Mark my request as resolved and get bucketId from request
-          bucketId = this._checkRequest(opt.data._id)
+        }
+        // if its from our own request, do a publish for each new/unknown meta content
+        if (data._id in this._requestBook) {
+          bucketId = this._checkRequest(data._id)
           if (bucketId === '') {
             return
           }
-          // get already known publishing list
-          let knownPublishingList = []
-          if (bucketId in this._publishedEntryBook) {
-            knownPublishingList = this._publishedEntryBook[bucketId]
-          }
-          // Update my book-keeping on what this agent has.
-          // and do a getEntry for every new entry
-          for (const entryAddress of opt.data.entryAddressList) {
-            if (knownPublishingList.includes(entryAddress)) {
-              log.t('Entry is known ', entryAddress)
-              continue
-            }
-            let fetchEntry = {
-              method: 'handleFetchEntry',
-              dnaAddress: opt.data.dnaAddress,
-              _id: this._createRequestWithBucket(bucketId),
-              requesterAgentId: '',
-              address: entryAddress
-            }
-            this._ipc.send('json', fetchEntry)
-          }
-          return
-        case 'handleGetHoldingEntryListResult':
-          // Note: opt.data is EntryListData
-          // Mark my request as resolved and get bucketId from request
-          bucketId = this._checkRequest(opt.data._id)
-          if (bucketId === '') {
-            return
-          }
-          // get already known publishing list
-          let knownHoldingList = []
-          if (bucketId in this._storedEntryBook) {
-            knownHoldingList = this._storedEntryBook[bucketId]
-          }
-          // Update my book-keeping on what this agent has.
-          for (const entryAddress of opt.data.entryAddressList) {
-            if (knownHoldingList.includes(entryAddress)) {
-              continue
-            }
-            this._bookkeepAddressWithBucket(this._storedEntryBook, bucketId, entryAddress)
-          }
-          return
-
-        case 'handleGetPublishingMetaListResult':
-          // Note: opt.data is MetaListData
-          // Mark my request as resolved and get bucketId from request
-          bucketId = this._checkRequest(opt.data._id)
-          if (bucketId === '') {
-            return
-          }
-
+          log.t('Handle our handleFetchMetaResult:', data._id, bucketId)
           // get already known publishing list
           let knownPublishingMetaList = []
           if (bucketId in this._publishedMetaBook) {
             knownPublishingMetaList = this._publishedMetaBook[bucketId]
           }
-
-          // Update my book-keeping on what this agent has.
-          // and do a getEntry for every new entry
-          let requestedMetaKey = []
-          for (const metaTuple of opt.data.metaList) {
-            let metaId = this._intoMetaId(metaTuple[0], metaTuple[1], metaTuple[2])
+          for (const metaContent of data.contentList) {
+            let metaId = this._intoMetaId(data.entryAddress, data.attribute, metaContent)
             if (knownPublishingMetaList.includes(metaId)) {
               continue
             }
-            // dont send same request twice
-            const metaKey = '' + metaTuple[0] + '+' + metaTuple[1]
-            if (requestedMetaKey.includes(metaKey)) {
-              continue
-            }
-            requestedMetaKey.push(metaKey)
-
-            let fetchMeta = {
-              method: 'handleFetchMeta',
-              dnaAddress: opt.data.dnaAddress,
-              _id: this._createRequestWithBucket(bucketId),
-              requesterAgentId: '',
-              entryAddress: metaTuple[0],
-              attribute: metaTuple[1]
-            }
-            this._ipc.send('json', fetchMeta)
+            this._getMemRef(data.dnaAddress).mem.insert({
+              type: 'dhtMeta',
+              providerAgentId: data.providerAgentId,
+              entryAddress: data.entryAddress,
+              attribute: data.attribute,
+              contentList: [metaContent]
+            })
           }
           return
-
-        case 'handleGetHoldingMetaListResult':
-          // Note: opt.data is MetaListData
-          // Mark my request as resolved and get bucketId from request
-          bucketId = this._checkRequest(opt.data._id)
-          if (bucketId === '') {
-            return
-          }
-          // get already known publishing list
-          let knownHoldingMetaList = []
-          if (bucketId in this._storedMetaBook) {
-            knownHoldingMetaList = this._storedMetaBook[bucketId]
-          }
-          // Update my book-keeping on what this agent has.
-          for (const metaTuple of opt.data.metaList) {
-            let metaId = this._intoMetaId(metaTuple[0], metaTuple[1], metaTuple[2])
-            if (knownHoldingMetaList.includes(metaId)) {
-              continue
-            }
-            this._bookkeepAddressWithBucket(this._storedMetaBook, bucketId, metaId)
-          }
+        }
+        // otherwise since we're fully connected, just redirect this back to itself for now..
+        // Transfer this id only once
+        if (this._transferedRequestList.includes(data._id)) {
           return
-      }
+        }
+        this._transferedRequestList.push(data._id)
+        log.t('Transfer handleFetchMetaResult as fetchMetaResult:', data._id)
+        data.method = 'fetchMetaResult'
+        this._ipc.send('json', data)
+        return
+
+      case 'handleGetPublishingEntryListResult':
+        // Note: data is EntryListData
+        // Mark my request as resolved and get bucketId from request
+        bucketId = this._checkRequest(data._id)
+        if (bucketId === '') {
+          return
+        }
+        // get already known publishing list
+        let knownPublishingList = []
+        if (bucketId in this._publishedEntryBook) {
+          knownPublishingList = this._publishedEntryBook[bucketId]
+        }
+        // Update my book-keeping on what this agent has.
+        // and do a getEntry for every new entry
+        for (const entryAddress of data.entryAddressList) {
+          if (knownPublishingList.includes(entryAddress)) {
+            log.t('Entry is known ', entryAddress)
+            continue
+          }
+          let fetchEntry = {
+            method: 'handleFetchEntry',
+            dnaAddress: data.dnaAddress,
+            _id: this._createRequestWithBucket(bucketId),
+            requesterAgentId: '',
+            address: entryAddress
+          }
+          this._ipc.send('json', fetchEntry)
+        }
+        return
+      case 'handleGetHoldingEntryListResult':
+        // Note: data is EntryListData
+        // Mark my request as resolved and get bucketId from request
+        bucketId = this._checkRequest(data._id)
+        if (bucketId === '') {
+          return
+        }
+        // get already known publishing list
+        let knownHoldingList = []
+        if (bucketId in this._storedEntryBook) {
+          knownHoldingList = this._storedEntryBook[bucketId]
+        }
+        // Update my book-keeping on what this agent has.
+        for (const entryAddress of data.entryAddressList) {
+          if (knownHoldingList.includes(entryAddress)) {
+            continue
+          }
+          this._bookkeepAddressWithBucket(this._storedEntryBook, bucketId, entryAddress)
+        }
+        return
+
+      case 'handleGetPublishingMetaListResult':
+        // Note: data is MetaListData
+        // Mark my request as resolved and get bucketId from request
+        bucketId = this._checkRequest(data._id)
+        if (bucketId === '') {
+          return
+        }
+
+        // get already known publishing list
+        let knownPublishingMetaList = []
+        if (bucketId in this._publishedMetaBook) {
+          knownPublishingMetaList = this._publishedMetaBook[bucketId]
+        }
+
+        // Update my book-keeping on what this agent has.
+        // and do a getEntry for every new entry
+        let requestedMetaKey = []
+        for (const metaTuple of data.metaList) {
+          let metaId = this._intoMetaId(metaTuple[0], metaTuple[1], metaTuple[2])
+          if (knownPublishingMetaList.includes(metaId)) {
+            continue
+          }
+          // dont send same request twice
+          const metaKey = '' + metaTuple[0] + '+' + metaTuple[1]
+          if (requestedMetaKey.includes(metaKey)) {
+            continue
+          }
+          requestedMetaKey.push(metaKey)
+
+          let fetchMeta = {
+            method: 'handleFetchMeta',
+            dnaAddress: data.dnaAddress,
+            _id: this._createRequestWithBucket(bucketId),
+            requesterAgentId: '',
+            entryAddress: metaTuple[0],
+            attribute: metaTuple[1]
+          }
+          this._ipc.send('json', fetchMeta)
+        }
+        return
+
+      case 'handleGetHoldingMetaListResult':
+        // Note: data is MetaListData
+        // Mark my request as resolved and get bucketId from request
+        bucketId = this._checkRequest(data._id)
+        if (bucketId === '') {
+          return
+        }
+        // get already known publishing list
+        let knownHoldingMetaList = []
+        if (bucketId in this._storedMetaBook) {
+          knownHoldingMetaList = this._storedMetaBook[bucketId]
+        }
+        // Update my book-keeping on what this agent has.
+        for (const metaTuple of data.metaList) {
+          let metaId = this._intoMetaId(metaTuple[0], metaTuple[1], metaTuple[2])
+          if (knownHoldingMetaList.includes(metaId)) {
+            continue
+          }
+          this._bookkeepAddressWithBucket(this._storedMetaBook, bucketId, metaId)
+        }
+        return
     }
 
-    throw new Error('unexpected input ' + JSON.stringify(opt))
+    throw new Error('unexpected input ' + JSON.stringify(data))
   }
 
   /**

--- a/packages/n3h-mock/lib/index.js
+++ b/packages/n3h-mock/lib/index.js
@@ -1,6 +1,5 @@
 
 const { N3hMode } = require('../../n3h-ipc/lib/n3hMode')
-//const { IpcServer } = require('@holochain/n3h-ipc')
 
 const { Mem } = require('./mem')
 
@@ -211,7 +210,6 @@ class N3hMock extends N3hMode {
           if (bucketId === '') {
             return
           }
-          log.t('Handle our handleFetchMetaResult:', data._id, bucketId)
           // get already known publishing list
           let knownPublishingMetaList = []
           if (bucketId in this._publishedMetaBook) {

--- a/packages/n3h-mock/lib/index.js
+++ b/packages/n3h-mock/lib/index.js
@@ -163,8 +163,7 @@ class N3hMock extends N3hMode {
         if (!this._hasTrackOrFail(data.requesterAgentId, data.dnaAddress, data._id)) {
           return
         }
-        // erm... since we're fully connected,
-        // just redirect this back to itself for now...
+        // Since we're fully connected, just redirect this back to itself for now...
         data.method = 'handleFetchEntry'
         this._ipcSendOne(senderId, 'json', data)
         return
@@ -181,14 +180,18 @@ class N3hMock extends N3hMode {
           })
           return
         }
-        // otherwise since we're fully connected, just redirect this back to itself for now...
+        // Requester must track DNA
+        tId = this._getTransportIdOrFail(data.dnaAddress, data.requesterAgentId)
+        if (tId === null) {
+          return
+        }
         // Transfer this id only once
         if (this._transferedRequestList.includes(data._id)) {
           return
         }
         this._transferedRequestList.push(data._id)
         data.method = 'fetchEntryResult'
-        this._ipcSendOne(senderId, 'json', data)
+        this._ipcSendOne(tId, 'json', data)
         return
       case 'fetchMeta':
         // Note: data is a FetchMetaData
@@ -229,7 +232,11 @@ class N3hMock extends N3hMode {
           }
           return
         }
-        // otherwise since we're fully connected, just redirect this back to itself for now..
+        // Requester must track DNA
+        tId = this._getTransportIdOrFail(data.dnaAddress, data.requesterAgentId)
+        if (tId === null) {
+          return
+        }
         // Transfer this id only once
         if (this._transferedRequestList.includes(data._id)) {
           return
@@ -237,7 +244,7 @@ class N3hMock extends N3hMode {
         this._transferedRequestList.push(data._id)
         log.t('Transfer handleFetchMetaResult as fetchMetaResult:', data._id)
         data.method = 'fetchMetaResult'
-        this._ipcSendOne(senderId, 'json', data)
+        this._ipcSendOne(tId, 'json', data)
         return
 
       case 'handleGetPublishingEntryListResult':

--- a/packages/n3h-mock/package.json
+++ b/packages/n3h-mock/package.json
@@ -21,7 +21,6 @@
   },
   "dependencies": {
     "@holochain/n3h-common": "^0.0.1",
-    "@holochain/n3h-ipc": "^0.0.1",
     "@holochain/tweetlog": "^0.0.1"
   },
   "standard": {

--- a/packages/n3h/bin/n3h
+++ b/packages/n3h/bin/n3h
@@ -32,7 +32,7 @@ async function main () {
 
   // setup logging
   tweetlog.set('t') // enable trace logging
-  //tweetlog.listen(logHandler)
+  tweetlog.listen(logHandler)
 
   const quietMode = 'N3H_QUIET' in process.env
   if (!quietMode) {

--- a/packages/n3h/bin/n3h
+++ b/packages/n3h/bin/n3h
@@ -32,7 +32,7 @@ async function main () {
 
   // setup logging
   tweetlog.set('t') // enable trace logging
-  tweetlog.listen(logHandler)
+  //tweetlog.listen(logHandler)
 
   const quietMode = 'N3H_QUIET' in process.env
   if (!quietMode) {


### PR DESCRIPTION
Created base class `N3hMode`  in  `n3h-ipc/lib/n3hMode`. (might not be the right place but re-org is going to change that anyway...)
Common to hackmode and n3h-mock. Handles the wss ipc connection for the most part.
Fixed n3h-mock to account for the new wss ipc connection.
Added `_ipcSendOne()` function.
