### PR TITLE
attempt to fix intermitent ci failure

### DIFF
--- a/lib/hackmode/p2p-backend-hackmode-peer.js
+++ b/lib/hackmode/p2p-backend-hackmode-peer.js
@@ -202,7 +202,7 @@ class P2pBackendHackmodePeer extends AsyncClass {
       throw new Error('data must be a Buffer')
     }
     // Connect to all provided peers
-    
+
     let cIds = await Promise.all(peerAddressList.map(
       a => this._ensureCIdForPeerAddress(a).catch(e => {
         if (!timeoutRegex.test(e)) {
@@ -325,13 +325,17 @@ class P2pBackendHackmodePeer extends AsyncClass {
     // Handle event by type
     switch (e.type) {
       case 'gossipTo':
-        await this._publish(
-          null,
-          this._keyBundle.getId(),
-          e.peerList,
-          '$gossip$',
-          Buffer.from(e.bundle, 'base64')
-        )
+        try {
+          await this._publish(
+            null,
+            this._keyBundle.getId(),
+            e.peerList,
+            '$gossip$',
+            Buffer.from(e.bundle, 'base64')
+          )
+        } catch (e) {
+          log.w('gossip failed, connection drop?', e)
+        }
         break
       case 'peerHoldRequest':
         // no validation / indexing for now,


### PR DESCRIPTION
@Connoropolous - attempt to address the failure we were seeing:

```
Handle Dht Event Error { type: 'gossipTo',
  peerList: 
   [ 'HcScIM3Y5WMZjyoebxIk4bFutwdg6y9guvo4UqVmDK9fawn8A8R39kS8MS683oa' ],
  bundle: 'k6lsb2NIYXNoZXOsay5zYmUyenB4anQ5xGNMy55dxK2Ws/kjMPNJmdG67YV/Dv5MGPe9zrAsG1yyOqwAOuVHI9nMX2nOpiROj++ipxaT5iGfBDwVDpqtl8SLTR4Gdou+3MpltqlD6nyjsCFOyNdPiZ/yLF/oXYdxYoK2XPk=' } Error: instance used after destruction
    at Connection.$checkDestroyed (/Users/travis/build/holochain/n3h/lib/n3h-common/async-class.js:64:144)
    at Connection.send (/Users/travis/build/holochain/n3h/lib/n3h-mod-spec/connection-spec.js:50:78)
    at P2pBackendHackmodePeer._sendByCId (/Users/travis/build/holochain/n3h/lib/hackmode/p2p-backend-hackmode-peer.js:46:319)
    at P2pBackendHackmodePeer._publish (/Users/travis/build/holochain/n3h/lib/hackmode/p2p-backend-hackmode-peer.js:44:36)
    at <anonymous>
```