### PR TITLE
fix for jessie-backports being end-of-lifed in our docker ci

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ n3h delivers the networking component for [holochain-rust](https://github.com/ho
 
 Version 0.0.3 of Holochain was the first to use n3h as its networking component. For each version of the Holochain you must use the a compatible version of n3h.  Make sure to download the tagged release to download a version of n3h that is guaranteed to work with the equivalent Holochain version:
 
-### 0.0.9-alpha1
-- [https://github.com/holochain/n3h/releases/tag/v0.0.9-alpha1](https://github.com/holochain/n3h/releases/tag/v0.0.9-alpha1)
+### 0.0.9-alpha2
+- [https://github.com/holochain/n3h/releases/tag/v0.0.9-alpha2](https://github.com/holochain/n3h/releases/tag/v0.0.9-alpha2)
 - [https://github.com/holochain/holochain-rust/releases/tag/v0.0.9-alpha](https://github.com/holochain/holochain-rust/releases/tag/v0.0.9-alpha)
 
 ### 0.0.7-alpha1

--- a/build/release-build-appimage.bash
+++ b/build/release-build-appimage.bash
@@ -48,6 +48,20 @@ function exec_dockcross() {
 FROM dockcross/linux-$DOCKCROSS_ARCH
 
 ENV DEFAULT_DOCKCROSS_IMAGE $TC_IMG_NAME
+
+RUN printf \
+'deb http://cdn-fastly.deb.debian.org/debian/ jessie main\n'\
+'deb-src http://cdn-fastly.deb.debian.org/debian/ jessie main\n'\
+'\n'\
+'deb http://security.debian.org/ jessie/updates main\n'\
+'deb-src http://security.debian.org/ jessie/updates main\n'\
+'\n'\
+'deb http://archive.debian.org/debian jessie-backports main\n'\
+'deb-src http://archive.debian.org/debian jessie-backports main\n'\
+> /etc/apt/sources.list
+
+RUN echo 'Acquire::Check-Valid-Until "false";' >> /etc/apt/apt.conf
+
 RUN apt-get update && apt-get install -y fuse qemu-system-aarch64
 EOF
   docker build -t $TC_IMG_NAME .

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n3h",
-  "version": "0.0.9-alpha1",
+  "version": "0.0.9-alpha2",
   "description": "nodejs holochain networking library with swapable / configurable modules",
   "repository": "github:holochain/n3h",
   "bin": {


### PR DESCRIPTION
@Connoropolous - I fixed the build error around jessie-backports being end-of-life-d ... let me know if it's ok that we use [0.0.9-alpha2](https://github.com/holochain/n3h/releases/tag/untagged-02040d514c10c6b1ee2d) and discard the draft release for 0.0.9-alpha1