### PR TITLE
transportId persistence

### DIFF
--- a/lib/exe.js
+++ b/lib/exe.js
@@ -71,7 +71,7 @@ async function main () {
 
   try {
     rawConfigData = JSON.parse((await _tryReadStdin()).toString())
-    log.w('got stdin config!', rawConfigData)
+    log.i('got stdin config!', rawConfigData)
   } catch (e) {
     log.w('could not read stdin', e)
   }
@@ -166,7 +166,7 @@ async function _tryReadStdin () {
       reject(timeout)
     }, 4000)
 
-    log.w('attempting read stdin')
+    log.d('attempting read stdin')
     process.stdin.resume()
 
     let data = Buffer.alloc(0)

--- a/lib/exe.js
+++ b/lib/exe.js
@@ -62,6 +62,11 @@ async function main () {
     })
   }
 
+  log.i(' |||| wordDir |||')
+  // log.t('envs:', process.env)
+  log.i(' |||| wordDir |||', workDir)
+
+
   let rawConfigData = null
 
   try {
@@ -90,6 +95,12 @@ async function main () {
   if ('N3H_MODE' in process.env) {
     mode = process.env.N3H_MODE
   }
+
+  // environment webproxy bind override
+  // if ('N3H_BIND' in process.env) {
+  //   log.i('N3H_BIND found', process.env.N3H_BIND)
+  //   rawConfigData['webproxy']['connection']['bind'] = [process.env.N3H_BIND]
+  // }
 
   var n3hNode = null
 

--- a/lib/exe.js
+++ b/lib/exe.js
@@ -61,11 +61,7 @@ async function main () {
       console.error(`(${tag}) [${level}] ${args}`)
     })
   }
-
-  log.i(' |||| wordDir |||')
-  // log.t('envs:', process.env)
-  log.i(' |||| wordDir |||', workDir)
-
+  log.i('|| workDir ||', workDir)
 
   let rawConfigData = null
 
@@ -95,12 +91,6 @@ async function main () {
   if ('N3H_MODE' in process.env) {
     mode = process.env.N3H_MODE
   }
-
-  // environment webproxy bind override
-  // if ('N3H_BIND' in process.env) {
-  //   log.i('N3H_BIND found', process.env.N3H_BIND)
-  //   rawConfigData['webproxy']['connection']['bind'] = [process.env.N3H_BIND]
-  // }
 
   var n3hNode = null
 

--- a/lib/hackmode/p2p-backend-hackmode-peer.js
+++ b/lib/hackmode/p2p-backend-hackmode-peer.js
@@ -39,8 +39,8 @@ class P2pBackendHackmodePeer extends AsyncClass {
    * @returns {keyBundle}
    */
   async loadKey (workDir) {
-    // util.pwhashOpslimit = mosodium.pwhash.OPSLIMIT_INTERACTIVE
-    // util.pwhashMemlimit = mosodium.pwhash.MEMLIMIT_INTERACTIVE
+    util.pwhashOpslimit = mosodium.pwhash.OPSLIMIT_INTERACTIVE
+    util.pwhashMemlimit = mosodium.pwhash.MEMLIMIT_INTERACTIVE
     let bundle = null
     try {
       bundle = await this.loadKeyFromDisk(workDir)
@@ -54,12 +54,14 @@ class P2pBackendHackmodePeer extends AsyncClass {
       log.i('keyBundleed', bundle.getId())
       // Persist new key
       // let passphrase = await mosodium.SecBuf.ref(fakePassphrase)
-      let passphrase = await mosodium.SecBuf.ref(Buffer.from('hello'))
-      log.i('passphraseed')
-      const blob = await bundle.getBlob(passphrase, 'transportId')
+      // let passphrase = await mosodium.SecBuf.ref(Buffer.from('hello'))
+      let passphrase = Buffer.from('hello')
+      log.i('passphraseed', passphrase)
+      let blob = await bundle.getBlob(passphrase, 'transportId')
       log.i('blobed', blob.hint)
       try {
-        fs.writeFileSync(workDir + '/transportId.keyfile', JSON.stringify(blob))
+        // blob = JSON.stringify(blob)
+        fs.writeFileSync(workDir + '/transportId.keyfile', blob)
       } catch (err) {
         log.w('Write key to disk failed - ', err)
       }
@@ -77,9 +79,9 @@ class P2pBackendHackmodePeer extends AsyncClass {
       throw new Error('missing workDir')
     }
     log.t('workDir:', workDir)
-    const dataJson = fs.readFileSync(workDir + '/transportId.keyfile')
-    // log.t('dataJson', dataJson.toString())
-    const data = JSON.parse(dataJson)
+    let data = fs.readFileSync(workDir + '/transportId.keyfile')
+    log.t('data', data.toString())
+    // data = JSON.parse(data)
     return KeyBundle.fromBlob(data, await mosodium.SecBuf.ref(fakePassphrase))
   }
 
@@ -98,7 +100,7 @@ class P2pBackendHackmodePeer extends AsyncClass {
 
     // load key from persistency folder
     this._keyBundle = await this.loadKey(initOptions.workDir)
-    log.i('peerId:', this._keyBundle.getId())
+    log.i('transportId:', this._keyBundle.getId())
 
     // Create Connection
     this._con = await new Connection(ConnectionBackendWss, initOptions.connection)

--- a/lib/hackmode/p2p-backend-hackmode-peer.js
+++ b/lib/hackmode/p2p-backend-hackmode-peer.js
@@ -19,6 +19,10 @@ const {
 const { ConnectionBackendWss } = require('../n3h-mod-connection-wss')
 const { DhtBackendFullsync } = require('../n3h-mod-dht-fullsync')
 
+const fs = require('fs')
+
+const fake_passphrase = "hackmode_passphrase"
+
 /**
  * @param {object} options
  * @param {object} options.dht
@@ -28,6 +32,41 @@ const { DhtBackendFullsync } = require('../n3h-mod-dht-fullsync')
  * @param {string} [options.wssRelayPeer] - if set, advertise this node as relaying through a specific peer target at this peerTransport address. must be a direct address, not another relay.
  */
 class P2pBackendHackmodePeer extends AsyncClass {
+  /**
+   *
+   * @param workDir
+   * @returns {keyBundle}
+   */
+  async loadKey (workDir) {
+    try {
+      return this.loadKeyFromDisk(workDir)
+    } catch (err) {
+      console.log('loadKeyFromDisk failed', err)
+      // Generate new transportId with a random seed
+      const seed = await mosodium.SecBuf.secure(32)
+      await seed.randomize()
+      const keyBundle = KeyBundle.newFromSeed(seed)
+      // Persist new key
+      const blob = keyBundle.getBlob(fake_passphrase, 'transportId')
+      fs.writeFileSync(workDir + '/transportId.keyfile', blob)
+      return keyBundle
+    }
+  }
+
+  /**
+   *
+   * @param workDir
+   * @returns {Promise<KeyBundle>}
+   */
+  async loadKeyFromDisk (workDir) {
+    if (!workDir) {
+      throw new Error('missing workDir')
+    }
+    const data = fs.readFileSync(workDir + '/transportId.keyfile')
+    console.log(data.toString())
+    return KeyBundle.fromBlob(data, fake_passphrase)
+  }
+
   /**
    */
   async init (spec, initOptions) {
@@ -41,10 +80,8 @@ class P2pBackendHackmodePeer extends AsyncClass {
     // Map of connection -> PeerAddress
     this._conByPeerAddress = new Map()
 
-    // Create ID with a a random KeyBundle
-    const seed = await mosodium.SecBuf.secure(32)
-    await seed.randomize()
-    this._keyBundle = await KeyBundle.newFromSeed(seed)
+    // load key from persistency folder
+    this._keyBundle = await this.loadKey(initOptions.workDir)
     log.i('peerId:', this._keyBundle.getId())
 
     // Create Connection
@@ -85,7 +122,7 @@ class P2pBackendHackmodePeer extends AsyncClass {
       throw new Error('required either wssAdvertise or wssRelayPeers')
     }
 
-    // Init Peer Discovery DHT
+    // Init Peer Discovery DHT, e.g. transportDht
     initOptions.dht.thisPeer = this._wssAdvertise
     this._dht = await new Dht(DhtBackendFullsync, initOptions.dht)
     this._dht.on('event', e => this._handleDhtEvent(e).catch(err => {
@@ -237,7 +274,7 @@ class P2pBackendHackmodePeer extends AsyncClass {
    * (called by this.transportConnect() and this._ensureCIdForPeerAddress())
    */
   async _ensureConnection (remoteAdvertise) {
-    // get uri and PeerId
+    // unpack uri and PeerId from advertise
     const uri = new URL(remoteAdvertise)
     if (!uri.searchParams.has('a')) {
       throw new Error('cannot connect to peer without nodeId ("a" param)')

--- a/lib/hackmode/p2p-backend-hackmode-peer.js
+++ b/lib/hackmode/p2p-backend-hackmode-peer.js
@@ -36,12 +36,10 @@ const KEY_FILENAME = 'transportId.keyfile'
  */
 class P2pBackendHackmodePeer extends AsyncClass {
   /**
-   * @param workDir - Directory where to search for the keyfile
+   * @param {String} workDir - Directory where to search for the keyfile
    * @returns {keyBundle} KeyBundle loaded from disk or randomly generated and saved to disk
    */
   async loadKey (workDir) {
-    util.pwhashOpslimit = mosodium.pwhash.OPSLIMIT_INTERACTIVE
-    util.pwhashMemlimit = mosodium.pwhash.MEMLIMIT_INTERACTIVE
     let bundle = null
     try {
       bundle = await this.loadKeyFromDisk(workDir)
@@ -49,14 +47,14 @@ class P2pBackendHackmodePeer extends AsyncClass {
     } catch (err) {
       log.w('loadKeyFromDisk failed - Generating a new transport keyBundle')
       // Generate new transportId with a random seed
-      const seed = await mosodium.SecBuf.secure(32)
+      const seed = await mosodium.SecBuf.secure(mosodium.sign.SEED_BYTES)
       await seed.randomize()
       bundle = await KeyBundle.newFromSeed(seed)
       // Persist new key
       let blob = await bundle.getBlob(FAKE_PASSPHRASE, 'transportId')
       blob = JSON.stringify(blob)
       try {
-        const keyfilepath = path.resolve(path.join(workDir, KEY_FILENAME))
+        const keyfilepath = path.resolve(workDir, KEY_FILENAME)
         fs.writeFileSync(keyfilepath, blob)
       } catch (err) {
         log.w('Writing keyfile to disk failed - ', err)
@@ -73,7 +71,7 @@ class P2pBackendHackmodePeer extends AsyncClass {
     if (!workDir) {
       throw new Error('missing workDir argument')
     }
-    log.t('workDir:', workDir)
+    log.t('loadKeyFromDisk - workDir:', workDir)
     const keyfilepath = path.resolve(workDir, KEY_FILENAME)
     let blob = fs.readFileSync(keyfilepath)
     blob = JSON.parse(blob)

--- a/lib/hackmode/p2p-backend-hackmode-peer.js
+++ b/lib/hackmode/p2p-backend-hackmode-peer.js
@@ -23,8 +23,8 @@ const { DhtBackendFullsync } = require('../n3h-mod-dht-fullsync')
 const fs = require('fs')
 const path = require('path')
 
-const fakePassphrase = Buffer.from('hackmode_passphrase')
-const keyfilename = 'transportId.keyfile'
+const FAKE_PASSPHRASE = Buffer.from('hackmode_passphrase')
+const KEY_FILENAME = 'transportId.keyfile'
 
 /**
  * @param {object} options
@@ -54,10 +54,10 @@ class P2pBackendHackmodePeer extends AsyncClass {
       await seed.randomize()
       bundle = await KeyBundle.newFromSeed(seed)
       // Persist new key
-      let blob = await bundle.getBlob(fakePassphrase, 'transportId')
+      let blob = await bundle.getBlob(FAKE_PASSPHRASE, 'transportId')
       blob = JSON.stringify(blob)
       try {
-        const keyfilepath = path.resolve(path.join(workDir, keyfilename))
+        const keyfilepath = path.resolve(path.join(workDir, KEY_FILENAME))
         fs.writeFileSync(keyfilepath, blob)
       } catch (err) {
         log.w('Writing keyfile to disk failed - ', err)
@@ -76,11 +76,11 @@ class P2pBackendHackmodePeer extends AsyncClass {
       throw new Error('missing workDir argument')
     }
     log.t('workDir:', workDir)
-    const keyfilepath = path.resolve(path.join(workDir, keyfilename))
+    const keyfilepath = path.resolve(path.join(workDir, KEY_FILENAME))
     let blob = fs.readFileSync(keyfilepath)
     blob = JSON.parse(blob)
     blob.data = Buffer.from(blob.data, 'base64')
-    return KeyBundle.fromBlob(blob, await mosodium.SecBuf.ref(fakePassphrase))
+    return KeyBundle.fromBlob(blob, await mosodium.SecBuf.ref(FAKE_PASSPHRASE))
   }
 
   /**

--- a/lib/hackmode/p2p-backend-hackmode-peer.js
+++ b/lib/hackmode/p2p-backend-hackmode-peer.js
@@ -51,16 +51,10 @@ class P2pBackendHackmodePeer extends AsyncClass {
       const seed = await mosodium.SecBuf.secure(32)
       await seed.randomize()
       bundle = await KeyBundle.newFromSeed(seed)
-      log.i('keyBundleed', bundle.getId())
       // Persist new key
-      // let passphrase = await mosodium.SecBuf.ref(fakePassphrase)
-      // let passphrase = await mosodium.SecBuf.ref(Buffer.from('hello'))
-      let passphrase = Buffer.from('hello')
-      log.i('passphraseed', passphrase)
-      let blob = await bundle.getBlob(passphrase, 'transportId')
-      log.i('blobed', blob.hint)
+      let blob = await bundle.getBlob(fakePassphrase, 'transportId')
+      blob = JSON.stringify(blob)
       try {
-        // blob = JSON.stringify(blob)
         fs.writeFileSync(workDir + '/transportId.keyfile', blob)
       } catch (err) {
         log.w('Write key to disk failed - ', err)
@@ -79,10 +73,10 @@ class P2pBackendHackmodePeer extends AsyncClass {
       throw new Error('missing workDir')
     }
     log.t('workDir:', workDir)
-    let data = fs.readFileSync(workDir + '/transportId.keyfile')
-    log.t('data', data.toString())
-    // data = JSON.parse(data)
-    return KeyBundle.fromBlob(data, await mosodium.SecBuf.ref(fakePassphrase))
+    let blob = fs.readFileSync(workDir + '/transportId.keyfile')
+    blob = JSON.parse(blob)
+    blob.data = Buffer.from(blob.data, 'base64')
+    return KeyBundle.fromBlob(blob, await mosodium.SecBuf.ref(fakePassphrase))
   }
 
   /**

--- a/lib/hackmode/p2p-backend-hackmode-peer.js
+++ b/lib/hackmode/p2p-backend-hackmode-peer.js
@@ -1,7 +1,6 @@
 const { AsyncClass, Track } = require('../n3h-common')
 const { KeyBundle } = require('../hc-dpki')
 const mosodium = require('../mosodium')
-const util = require('../hc-dpki/util')
 const tweetlog = require('../tweetlog')
 const log = tweetlog('p2p-backend')
 

--- a/lib/hackmode/p2p-backend-hackmode-peer.js
+++ b/lib/hackmode/p2p-backend-hackmode-peer.js
@@ -1,6 +1,7 @@
 const { AsyncClass, Track } = require('../n3h-common')
 const { KeyBundle } = require('../hc-dpki')
 const mosodium = require('../mosodium')
+const util = require('../hc-dpki/util')
 const tweetlog = require('../tweetlog')
 const log = tweetlog('p2p-backend')
 
@@ -21,7 +22,7 @@ const { DhtBackendFullsync } = require('../n3h-mod-dht-fullsync')
 
 const fs = require('fs')
 
-const fake_passphrase = "hackmode_passphrase"
+const fakePassphrase = Buffer.from('hackmode_passphrase')
 
 /**
  * @param {object} options
@@ -38,19 +39,32 @@ class P2pBackendHackmodePeer extends AsyncClass {
    * @returns {keyBundle}
    */
   async loadKey (workDir) {
+    // util.pwhashOpslimit = mosodium.pwhash.OPSLIMIT_INTERACTIVE
+    // util.pwhashMemlimit = mosodium.pwhash.MEMLIMIT_INTERACTIVE
+    let bundle = null
     try {
-      return this.loadKeyFromDisk(workDir)
+      bundle = await this.loadKeyFromDisk(workDir)
+      log.i('loadKeyFromDisk success -', bundle.getId())
     } catch (err) {
-      console.log('loadKeyFromDisk failed', err)
+      log.w('loadKeyFromDisk failed - Generating a new transport keyBundle')
       // Generate new transportId with a random seed
       const seed = await mosodium.SecBuf.secure(32)
       await seed.randomize()
-      const keyBundle = KeyBundle.newFromSeed(seed)
+      bundle = await KeyBundle.newFromSeed(seed)
+      log.i('keyBundleed', bundle.getId())
       // Persist new key
-      const blob = keyBundle.getBlob(fake_passphrase, 'transportId')
-      fs.writeFileSync(workDir + '/transportId.keyfile', blob)
-      return keyBundle
+      // let passphrase = await mosodium.SecBuf.ref(fakePassphrase)
+      let passphrase = await mosodium.SecBuf.ref(Buffer.from('hello'))
+      log.i('passphraseed')
+      const blob = await bundle.getBlob(passphrase, 'transportId')
+      log.i('blobed', blob.hint)
+      try {
+        fs.writeFileSync(workDir + '/transportId.keyfile', JSON.stringify(blob))
+      } catch (err) {
+        log.w('Write key to disk failed - ', err)
+      }
     }
+    return bundle
   }
 
   /**
@@ -62,9 +76,11 @@ class P2pBackendHackmodePeer extends AsyncClass {
     if (!workDir) {
       throw new Error('missing workDir')
     }
-    const data = fs.readFileSync(workDir + '/transportId.keyfile')
-    console.log(data.toString())
-    return KeyBundle.fromBlob(data, fake_passphrase)
+    log.t('workDir:', workDir)
+    const dataJson = fs.readFileSync(workDir + '/transportId.keyfile')
+    // log.t('dataJson', dataJson.toString())
+    const data = JSON.parse(dataJson)
+    return KeyBundle.fromBlob(data, await mosodium.SecBuf.ref(fakePassphrase))
   }
 
   /**
@@ -96,6 +112,8 @@ class P2pBackendHackmodePeer extends AsyncClass {
       : []
     await Promise.all(bind.map(b => this._con.bind(b)))
 
+    // log.i('bind:', initOptions.connection.bind, bind)
+
     // Init _wssAdvertise & bootstrapPeer
     this._wssAdvertise = null
     let bootstrapPeer = null
@@ -105,6 +123,7 @@ class P2pBackendHackmodePeer extends AsyncClass {
         uri = this.getBindings().next().value
       }
       this._advertise(uri)
+      // log.i('uri:', uri)
     } else if (Array.isArray(initOptions.wssRelayPeers) && initOptions.wssRelayPeers.length) {
       bootstrapPeer = initOptions.wssRelayPeers[0]
       if (initOptions.wssRelayPeers.length > 1) {

--- a/lib/hackmode/p2p-backend-hackmode-peer.js
+++ b/lib/hackmode/p2p-backend-hackmode-peer.js
@@ -74,7 +74,7 @@ class P2pBackendHackmodePeer extends AsyncClass {
       throw new Error('missing workDir argument')
     }
     log.t('workDir:', workDir)
-    const keyfilepath = path.resolve(path.join(workDir, KEY_FILENAME))
+    const keyfilepath = path.resolve(workDir, KEY_FILENAME)
     let blob = fs.readFileSync(keyfilepath)
     blob = JSON.parse(blob)
     blob.data = Buffer.from(blob.data, 'base64')

--- a/lib/hackmode/p2p-backend-hackmode-peer.js
+++ b/lib/hackmode/p2p-backend-hackmode-peer.js
@@ -36,8 +36,7 @@ const KEY_FILENAME = 'transportId.keyfile'
  */
 class P2pBackendHackmodePeer extends AsyncClass {
   /**
-   *
-   * @param workDir - Directory to search the keyfile in
+   * @param workDir - Directory where to search for the keyfile
    * @returns {keyBundle} KeyBundle loaded from disk or randomly generated and saved to disk
    */
   async loadKey (workDir) {
@@ -67,9 +66,8 @@ class P2pBackendHackmodePeer extends AsyncClass {
   }
 
   /**
-   *
-   * @param workDir
-   * @returns {Promise<KeyBundle>}
+   * Attempt to load a keyfile from disk
+   * @param workDir - Directory where to search for the keyfile
    */
   async loadKeyFromDisk (workDir) {
     if (!workDir) {

--- a/lib/hackmode/p2p-backend-hackmode-peer.js
+++ b/lib/hackmode/p2p-backend-hackmode-peer.js
@@ -21,8 +21,10 @@ const { ConnectionBackendWss } = require('../n3h-mod-connection-wss')
 const { DhtBackendFullsync } = require('../n3h-mod-dht-fullsync')
 
 const fs = require('fs')
+const path = require('path')
 
 const fakePassphrase = Buffer.from('hackmode_passphrase')
+const keyfilename = 'transportId.keyfile'
 
 /**
  * @param {object} options
@@ -35,8 +37,8 @@ const fakePassphrase = Buffer.from('hackmode_passphrase')
 class P2pBackendHackmodePeer extends AsyncClass {
   /**
    *
-   * @param workDir
-   * @returns {keyBundle}
+   * @param workDir - Directory to search the keyfile in
+   * @returns {keyBundle} KeyBundle loaded from disk or randomly generated and saved to disk
    */
   async loadKey (workDir) {
     util.pwhashOpslimit = mosodium.pwhash.OPSLIMIT_INTERACTIVE
@@ -55,9 +57,10 @@ class P2pBackendHackmodePeer extends AsyncClass {
       let blob = await bundle.getBlob(fakePassphrase, 'transportId')
       blob = JSON.stringify(blob)
       try {
-        fs.writeFileSync(workDir + '/transportId.keyfile', blob)
+        const keyfilepath = path.resolve(path.join(workDir, keyfilename))
+        fs.writeFileSync(keyfilepath, blob)
       } catch (err) {
-        log.w('Write key to disk failed - ', err)
+        log.w('Writing keyfile to disk failed - ', err)
       }
     }
     return bundle
@@ -70,10 +73,11 @@ class P2pBackendHackmodePeer extends AsyncClass {
    */
   async loadKeyFromDisk (workDir) {
     if (!workDir) {
-      throw new Error('missing workDir')
+      throw new Error('missing workDir argument')
     }
     log.t('workDir:', workDir)
-    let blob = fs.readFileSync(workDir + '/transportId.keyfile')
+    const keyfilepath = path.resolve(path.join(workDir, keyfilename))
+    let blob = fs.readFileSync(keyfilepath)
     blob = JSON.parse(blob)
     blob.data = Buffer.from(blob.data, 'base64')
     return KeyBundle.fromBlob(blob, await mosodium.SecBuf.ref(fakePassphrase))
@@ -108,8 +112,6 @@ class P2pBackendHackmodePeer extends AsyncClass {
       : []
     await Promise.all(bind.map(b => this._con.bind(b)))
 
-    // log.i('bind:', initOptions.connection.bind, bind)
-
     // Init _wssAdvertise & bootstrapPeer
     this._wssAdvertise = null
     let bootstrapPeer = null
@@ -119,7 +121,6 @@ class P2pBackendHackmodePeer extends AsyncClass {
         uri = this.getBindings().next().value
       }
       this._advertise(uri)
-      // log.i('uri:', uri)
     } else if (Array.isArray(initOptions.wssRelayPeers) && initOptions.wssRelayPeers.length) {
       bootstrapPeer = initOptions.wssRelayPeers[0]
       if (initOptions.wssRelayPeers.length > 1) {

--- a/lib/hackmode/p2p-backend-hackmode-peer.test.js
+++ b/lib/hackmode/p2p-backend-hackmode-peer.test.js
@@ -184,7 +184,6 @@ describe('hackmode module p2p peer backend Suite', () => {
       unsafeCleanup: true
     })
     const dir = d.path
-    console.log('tempdir created', dir)
     try {
       const nodeBase = await newBasic(d.path)
       let bundleA = await nodeBase._backend._keyBundle

--- a/lib/hackmode/p2p-backend-hackmode-peer.test.js
+++ b/lib/hackmode/p2p-backend-hackmode-peer.test.js
@@ -7,6 +7,8 @@ const tweetlog = require('../tweetlog')
 const log = tweetlog('@@-unit-test-@@')
 // tweetlog.listen(tweetlog.console)
 
+const tmp = require('tmp-promise')
+
 const { expect } = require('chai')
 
 const { P2p } = require('../n3h-mod-spec')
@@ -51,11 +53,13 @@ describe('hackmode module p2p peer backend Suite', () => {
     })
   }
 
-  const newBasic = async () => {
+  const newBasic = async (workDir) => {
+    workDir || (workDir = '')
     const node = await new P2p(P2pBackendHackmodePeer, {
       dht: JSON.parse(dht),
       connection: JSON.parse(connection),
-      wssAdvertise: 'auto'
+      wssAdvertise: 'auto',
+      workDir: workDir
     })
     regNode(node)
     return node
@@ -107,7 +111,7 @@ describe('hackmode module p2p peer backend Suite', () => {
     } finally {
       await cleanup()
     }
-  })
+  }).timeout(10000)
 
   it('integration', async () => {
     try {
@@ -148,7 +152,7 @@ describe('hackmode module p2p peer backend Suite', () => {
     } finally {
       await cleanup()
     }
-  }).timeout(10000)
+  }).timeout(15000)
 
   it('node dropping should not fail other nodes', async () => {
     try {
@@ -172,6 +176,23 @@ describe('hackmode module p2p peer backend Suite', () => {
       await $sleep(1000)
     } finally {
       await cleanup()
+    }
+  }).timeout(10000)
+
+  it('node loadKey', async () => {
+    let d = await tmp.dir({
+      unsafeCleanup: true
+    })
+    const dir = d.path
+    console.log('tempdir created', dir)
+    try {
+      const nodeBase = await newBasic(d.path)
+      let bundleA = await nodeBase._backend._keyBundle
+      let bundleB = await nodeBase._backend.loadKey(dir)
+      expect(bundleA.getId()).equals(bundleB.getId())
+    } finally {
+      await cleanup()
+      d.cleanup()
     }
   }).timeout(10000)
 })

--- a/lib/hackmode/realmode.js
+++ b/lib/hackmode/realmode.js
@@ -92,7 +92,8 @@ class N3hRealMode extends N3hMode {
         passphrase: 'hello',
         rsaBits: this._config.webproxy.connection.rsaBits,
         bind: this._config.webproxy.connection.bind
-      }
+      },
+      workDir: this._workDir
     }
     if (this._config.webproxy.wssRelayPeers) {
       p2pConf.wssRelayPeers = this._config.webproxy.wssRelayPeers
@@ -710,7 +711,7 @@ class N3hRealMode extends N3hMode {
         log.t(this.me() + '.peerConnect', this.nick(evt.peerAddress))
         // Bookkeep known peers
         this._peerList.push(evt.peerAddress)
-        // Gossip back my tracked DNA (and agents)
+        // Gossip back my tracked DNA+Agents
         // convert to array
         let dnaByAgent = []
         for (const [agentId, dnas] of this._ipcDnaByAgent) {

--- a/lib/hackmode/realmode.js
+++ b/lib/hackmode/realmode.js
@@ -48,7 +48,7 @@ const { $sleep } = require('../n3h-common')
  */
 class N3hRealMode extends N3hMode {
   async init (workDir, rawConfigData) {
-    await super.init()
+    await super.init(workDir, rawConfigData)
 
     this._requestBook = new Map()
 

--- a/lib/hackmode/realmode.test.js
+++ b/lib/hackmode/realmode.test.js
@@ -6,4 +6,9 @@ describe('RealMode Suite', () => {
   it('should be a function', () => {
     expect(typeof lib.N3hRealMode).equals('function')
   })
+
+  it('should init', async () => {
+    let n3hNode = await new lib.N3hRealMode('.')
+    console.log('n3hMode nick is', n3hNode.me())
+  })
 })

--- a/lib/hc-dpki/keybundle.js
+++ b/lib/hc-dpki/keybundle.js
@@ -66,8 +66,8 @@ class KeyBundle extends AsyncClass {
    * @return {KeyBundle}
    */
   static async fromBlob (blob, passphrase) {
-    // blob = msgpack.decode(await util.pwDec(Buffer.from(blob.data, 'base64'), passphrase))
-    blob = msgpack.decode(Buffer.from(blob.data, 'base64'))
+    blob = msgpack.decode(await util.pwDec(Buffer.from(blob.data, 'base64'), passphrase))
+    //blob = msgpack.decode(Buffer.from(blob.data, 'base64'))
     return new KeyBundle({
       signPubId: blob[0],
       encPubId: blob[1],
@@ -129,12 +129,12 @@ class KeyBundle extends AsyncClass {
     await this._signPriv.readable(async (_sp) => {
       await this._encPriv.readable(async (_ep) => {
         const pack = msgpack.encode([this._signPubId, this._encPubId, _sp, _ep])
-        // const cipher = await util.pwEnc(pack, passphrase)
+        const cipher = await util.pwEnc(pack, passphrase)
         out = {
           type: 'hcKeyBundle',
           hint,
-          data: pack
-          // data: cipher
+          //data: pack
+          data: cipher
         }
       })
     })

--- a/lib/hc-dpki/keybundle.js
+++ b/lib/hc-dpki/keybundle.js
@@ -66,7 +66,8 @@ class KeyBundle extends AsyncClass {
    * @return {KeyBundle}
    */
   static async fromBlob (blob, passphrase) {
-    blob = msgpack.decode(await util.pwDec(Buffer.from(blob.data, 'base64'), passphrase))
+    // blob = msgpack.decode(await util.pwDec(Buffer.from(blob.data, 'base64'), passphrase))
+    blob = msgpack.decode(Buffer.from(blob.data, 'base64'))
     return new KeyBundle({
       signPubId: blob[0],
       encPubId: blob[1],
@@ -128,11 +129,12 @@ class KeyBundle extends AsyncClass {
     await this._signPriv.readable(async (_sp) => {
       await this._encPriv.readable(async (_ep) => {
         const pack = msgpack.encode([this._signPubId, this._encPubId, _sp, _ep])
-        const cipher = await util.pwEnc(pack, passphrase)
+        // const cipher = await util.pwEnc(pack, passphrase)
         out = {
           type: 'hcKeyBundle',
           hint,
-          data: cipher
+          data: pack
+          // data: cipher
         }
       })
     })

--- a/lib/hc-dpki/keybundle.js
+++ b/lib/hc-dpki/keybundle.js
@@ -124,22 +124,19 @@ class KeyBundle extends AsyncClass {
       throw new Error('hint must be a string')
     }
 
-    let out = null
+    let pack = null
     await this._signPriv.readable(async (_sp) => {
       await this._encPriv.readable(async (_ep) => {
-        const pack = msgpack.encode([this._signPubId, this._encPubId, _sp, _ep])
-        const cipher = await util.pwEnc(pack, passphrase)
-        out = {
-          type: 'hcKeyBundle',
-          hint,
-          data: cipher.toString('base64')
-        }
+        pack = msgpack.encode([this._signPubId, this._encPubId, _sp, _ep])
       })
     })
-
-    return out
+    const cipher = await util.pwEnc(pack, passphrase)
+    return {
+      type: 'hcKeyBundle',
+      hint,
+      data: cipher.toString('base64')
+    }
   }
-
   /**
    * get the identifier string
    * @return {string}

--- a/lib/hc-dpki/keybundle.js
+++ b/lib/hc-dpki/keybundle.js
@@ -133,8 +133,7 @@ class KeyBundle extends AsyncClass {
         out = {
           type: 'hcKeyBundle',
           hint,
-          //data: pack
-          data: cipher
+          data: cipher.toString('base64')
         }
       })
     })

--- a/lib/hc-dpki/keybundle.js
+++ b/lib/hc-dpki/keybundle.js
@@ -67,7 +67,6 @@ class KeyBundle extends AsyncClass {
    */
   static async fromBlob (blob, passphrase) {
     blob = msgpack.decode(await util.pwDec(Buffer.from(blob.data, 'base64'), passphrase))
-    //blob = msgpack.decode(Buffer.from(blob.data, 'base64'))
     return new KeyBundle({
       signPubId: blob[0],
       encPubId: blob[1],

--- a/lib/hc-dpki/keybundle.test.js
+++ b/lib/hc-dpki/keybundle.test.js
@@ -153,7 +153,7 @@ describe('KeyBundle Suite', () => {
   })
 
   it('should blob / unblob', async () => {
-    let passphrase = await mosodium.SecBuf.ref(Buffer.from('hello'))
+    let passphrase = Buffer.from('hello')
     const b = await bundle0.getBlob(passphrase, 'hola')
     expect(b.hint).equals('hola')
     expect(b.type).equals('hcKeyBundle')

--- a/lib/hc-dpki/seed.js
+++ b/lib/hc-dpki/seed.js
@@ -69,7 +69,7 @@ class Seed extends AsyncClass {
 
   /**
    * generate a persistence blob with hint info
-   * @param {string} passphrase - the encryption passphrase
+   * @param {SecBuf} passphrase - the encryption passphrase
    * @param {string} hint - additional info / description for persistence
    */
   async getBlob (passphrase, hint) {

--- a/lib/hc-dpki/util.js
+++ b/lib/hc-dpki/util.js
@@ -84,7 +84,6 @@ async function pwHash (pass, salt) {
   }
   let secret = await mosodium.SecBuf.secure(32)
 
-  //log.i('pwHash')
   await mosodium.pwhash.pwhash(secret, pass, salt, opt)
 
   if (salt instanceof mosodium.SecBuf) {

--- a/lib/hc-dpki/util.js
+++ b/lib/hc-dpki/util.js
@@ -84,6 +84,7 @@ async function pwHash (pass, salt) {
   }
   let secret = await mosodium.SecBuf.secure(32)
 
+  //log.i('pwHash')
   await mosodium.pwhash.pwhash(secret, pass, salt, opt)
 
   if (salt instanceof mosodium.SecBuf) {
@@ -99,7 +100,7 @@ exports.pwHash = pwHash
 /**
  * Helper for encrypting a buffer with a pwhash-ed passphrase
  * @param {Buffer} data
- * @param {string} passphrase
+ * @param {SecBuf} passphrase
  * @return {Buffer} - msgpack encoded of the encrypted data
  */
 async function pwEnc (data, passphrase) {

--- a/lib/hc-dpki/util.test.js
+++ b/lib/hc-dpki/util.test.js
@@ -64,4 +64,12 @@ describe('util Suite', () => {
       expect(encPub.toString('base64')).equals(PAIRS[i][1])
     })
   }
+
+  it('encode & decode password', async () => {
+    const data = Buffer.from(PAIRS[0][0], 'base64')
+    const passphrase = Buffer.from('test_passphrase')
+    const cipher = await util.pwEnc(data, passphrase)
+    const decrypted = await util.pwDec(cipher, passphrase)
+    expect(decrypted.compare(data)).equals(0)
+  }).timeout(10000)
 })

--- a/lib/mosodium/pwhash.test.js
+++ b/lib/mosodium/pwhash.test.js
@@ -38,4 +38,22 @@ describe('pwhash Suite', () => {
       output.destroy()
     ])
   })
+
+  it('should generate SENSITIVE consistantly', async () => {
+    const pw = Buffer.from('test')
+    const salt = Buffer.from('drUpmsHbWiQWMJqcp64PeW5KuFBY20flF1cBsmJudo8=')
+    const output = await mosodium.SecBuf.insecure(32)
+
+    await mosodium.pwhash.pwhash(output, pw, salt, {
+      opslimit: mosodium.pwhash.OPSLIMIT_SENSITIVE,
+      memlimit: mosodium.pwhash.MEMLIMIT_SENSITIVE
+    })
+
+    let res = null
+    await output.readable(r => { res = r.toString('base64') })
+
+    expect(res).equals('/gJBavAcMZpU4mczSEK7J7jhvCQ1ZnVvpAq8kPoktJ8=')
+
+    await output.destroy()
+  }).timeout(5000)
 })

--- a/lib/n3h-mock/index.js
+++ b/lib/n3h-mock/index.js
@@ -18,6 +18,10 @@ class N3hMock extends N3hMode {
 
     // Initialize members
     this._transferedRequestList = []
+
+    // make sure this is output despite our log settings
+    console.log('#P2P-BINDING#:' + 'ws://127.0.0.1/')
+    console.log('#P2P-READY#')
   }
 
   // ----------------------------------------------------------------------------------------------

--- a/lib/n3h-mod-dht-fullsync/dht-fullsync.js
+++ b/lib/n3h-mod-dht-fullsync/dht-fullsync.js
@@ -339,6 +339,22 @@ class DhtBackendFullsync extends AsyncClass {
         }
         console.error('TIMEOUT gossiping with peer', ref.peerAddress)
         this._gossipStack.pop()
+        // Remove peer from peerStore
+        // FIXME
+        // const loc = getLoc(ref.peerAddress)
+        // if (!this._peerStore.has(loc)) {
+        //   this._peerStore.set(loc, new Map())
+        // }
+        // const lRef = this._peerStore.get(loc)
+        // lRef.set(ref.peerAddress, {
+        //   transport: '',
+        //   data: '',
+        //   ts: 0
+        // })
+        // Notify owner
+        // const evt = DhtEvent.peerHoldRequest(peerAddress, '', '', 0)
+        // this._spec.$emitEvent(evt)
+        // this._spec.$emitEvent(DhtEvent.peerTimedout(ref.peerAddress))
         return setImmediate(() => this._gossip())
       }
     }

--- a/lib/n3h-mod-dht-fullsync/dht-fullsync.js
+++ b/lib/n3h-mod-dht-fullsync/dht-fullsync.js
@@ -339,22 +339,6 @@ class DhtBackendFullsync extends AsyncClass {
         }
         console.error('TIMEOUT gossiping with peer', ref.peerAddress)
         this._gossipStack.pop()
-        // Remove peer from peerStore
-        // FIXME
-        // const loc = getLoc(ref.peerAddress)
-        // if (!this._peerStore.has(loc)) {
-        //   this._peerStore.set(loc, new Map())
-        // }
-        // const lRef = this._peerStore.get(loc)
-        // lRef.set(ref.peerAddress, {
-        //   transport: '',
-        //   data: '',
-        //   ts: 0
-        // })
-        // Notify owner
-        // const evt = DhtEvent.peerHoldRequest(peerAddress, '', '', 0)
-        // this._spec.$emitEvent(evt)
-        // this._spec.$emitEvent(DhtEvent.peerTimedout(ref.peerAddress))
         return setImmediate(() => this._gossip())
       }
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "n3h",
-  "version": "0.0.9-alpha1",
+  "version": "0.0.9-alpha2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5296,6 +5296,16 @@
         "os-tmpdir": "~1.0.2"
       }
     },
+    "tmp-promise": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-1.0.5.tgz",
+      "integrity": "sha512-hOabTz9Tp49wCozFwuJe5ISrOqkECm6kzw66XTP23DuzNU7QS/KiZq5LC9Y7QSy8f1rPSLy4bKaViP0OwGI1cA==",
+      "dev": true,
+      "requires": {
+        "bluebird": "^3.5.0",
+        "tmp": "0.0.33"
+      }
+    },
     "to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "prompt": "^1.0.0",
     "sinon": "^7.1.1",
     "standard": "^12.0.1",
-    "tmp": "0.0.33"
+    "tmp": "0.0.33",
+    "tmp-promise": "1.0.5"
   },
   "dependencies": {
     "@holochain/hcid-js": "^0.0.5",


### PR DESCRIPTION
Generate - save - load a 'transportId.keyfile' from the workDir.
keyfile is json with base64 for the encrypted binary buffer

Added unit-tests along the way.
Made MockMocde shout a P2pReady for consistency.