### PR TITLE
Fix handling of meta items

### DIFF
--- a/lib/hackmode/realmode.js
+++ b/lib/hackmode/realmode.js
@@ -339,45 +339,10 @@ class N3hRealMode extends N3hMode {
         if (!this._hasTrackOrFail(data.requesterAgentId, data.dnaAddress, data._id)) {
           return
         }
-        // Ask my data DGT
-        // TODO: might need to do dht.post(DhtEvent.fetchData) instead for non-fullsync DHT
-        result = await this._getDhtRef(data.dnaAddress).fetchDataLocal(data.entryAddress)
-        if (result) {
-          result = JSON.parse(Buffer.from(result, 'base64').toString('utf8'))
-          log.d(this.me() + ' fetchMeta.fetchDataLocal', result)
-          // Search for meta of requested attribute
-          let contentList = []
-          for (const meta of result.meta) {
-            if (meta.attribute === data.attribute) {
-              contentList.push(meta.contentList[0])
-            }
-          }
-          // Determine providerAgentId ; Entry might not exist
-          let fromAgentId = result.dataFetchProviderAgentId
-          if (!(Object.entries(result.entry).length === 0 && result.entry.constructor === Object)) {
-            fromAgentId = result.entry.providerAgentId
-          }
-          // Create ipc message
-          ipcMsg = {
-            method: 'fetchMetaResult',
-            _id: data._id,
-            dnaAddress: data.dnaAddress,
-            requesterAgentId: data.requesterAgentId,
-            providerAgentId: fromAgentId,
-            entryAddress: data.entryAddress,
-            attribute: data.attribute,
-            contentList: contentList
-          }
-        } else {
-          ipcMsg = {
-            method: 'failureResult',
-            _id: data._id,
-            dnaAddress: data.dnaAddress,
-            toAgentId: data.requesterAgentId,
-            errorInfo: 'Entry not found during fetchMeta for:' + data.entryAddress
-          }
-        }
-        this._ipcSend('json', ipcMsg)
+        // erm... since we're fully connected,
+        // just redirect this back to itself for now...
+        data.method = 'handleFetchMeta'
+        this._ipcSend('json', data)
         return
       case 'handleFetchMetaResult':
         // Note: data is a FetchMetaResultData


### PR DESCRIPTION
Fixes https://github.com/holochain/n3h/issues/88.

The new REAL mode handling of `fetchMeta` relies on its own cache of entries and their meta items, but that seems to be dysfunctional as it never asks core for those entries/items (except for requesting the initial list on start-up, but that is not yet implemented in core). Also it assumes that a base entry has to be there for a meta-item to be able to exist.

Both assumption don't apply for the case of first authoring an entry.

I've reverted the handling of `fetchMeta` back to what is used in HACK mode. This solves the immediate problem that is blocking me and @pjkundert. @ddd-mtl wants to provide a fix of the code I've replaced here within the next hours.