### PR TITLE
Handle connection loss

### DIFF
--- a/lib/hackmode/p2p-backend-hackmode-peer.js
+++ b/lib/hackmode/p2p-backend-hackmode-peer.js
@@ -302,8 +302,14 @@ class P2pBackendHackmodePeer extends AsyncClass {
 
     switch (uri.protocol) {
       case 'wss:':
-        return this._ensureConnection(
-          peerInfo.peerTransport + '?a=' + peerInfo.peerAddress)
+        if (peerInfo.peerAddress === this.getId()) {
+          // Don't try to connect self
+          return Promise.resolve()
+        } else {
+          const remotePeerAddress = peerInfo.peerTransport + '?a=' + peerInfo.peerAddress
+          return this._ensureConnection(remotePeerAddress)
+        }
+
       case 'holorelay:':
         return this._ensureCIdForPeerAddress(uri.hostname)
       default:

--- a/lib/n3h-mod-connection-wss/wss-connection.js
+++ b/lib/n3h-mod-connection-wss/wss-connection.js
@@ -57,13 +57,12 @@ class ConnectionBackendWss extends AsyncClass {
         } else if (Date.now() - ws._$_lastMsg >= 2000) {
           try {
             ws.ping()
-          } catch(e) {
-            console.error("ERROR during ping to", id,":", e)
-            console.error("Shutting down connection...")
+          } catch (e) {
+            console.error('ERROR during ping to', id, ':', e)
+            console.error('Shutting down connection...')
             ws.close(1001, 'dropped connection')
             await this._handleClose(id)
           }
-
         }
       }
     }, 200)
@@ -200,8 +199,8 @@ class ConnectionBackendWss extends AsyncClass {
       const ws = this._cons.get(id)
       try {
         ws.send(Buffer.from(buf, 'base64'))
-      } catch(e) {
-        console.error("ERROR trying to send buffer over websocket:", e)
+      } catch (e) {
+        console.error('ERROR trying to send buffer over websocket:', e)
       }
     }
   }

--- a/lib/n3h-mod-connection-wss/wss-connection.js
+++ b/lib/n3h-mod-connection-wss/wss-connection.js
@@ -55,7 +55,15 @@ class ConnectionBackendWss extends AsyncClass {
           ws.close(1001, 'stale connection')
           await this._handleClose(id)
         } else if (Date.now() - ws._$_lastMsg >= 2000) {
-          ws.ping()
+          try {
+            ws.ping()
+          } catch(e) {
+            console.error("ERROR during ping to", id,":", e)
+            console.error("Shutting down connection...")
+            ws.close(1001, 'dropped connection')
+            await this._handleClose(id)
+          }
+
         }
       }
     }, 200)
@@ -190,7 +198,11 @@ class ConnectionBackendWss extends AsyncClass {
         throw new Error('unknown connection id: ' + id)
       }
       const ws = this._cons.get(id)
-      ws.send(Buffer.from(buf, 'base64'))
+      try {
+        ws.send(Buffer.from(buf, 'base64'))
+      } catch(e) {
+        console.error("ERROR trying to send buffer over websocket:", e)
+      }
     }
   }
 

--- a/lib/n3h-mod-dht-fullsync/dht-fullsync.js
+++ b/lib/n3h-mod-dht-fullsync/dht-fullsync.js
@@ -375,8 +375,7 @@ class DhtBackendFullsync extends AsyncClass {
         }
         console.error('TIMEOUT gossiping with peer', ref.peerAddress)
         this._gossipStack.pop()
-        // Remove peer from peerStore
-        this.dropPeerLocal(ref.peerAddress)
+
         // Notify owner
         if (this._spec) {
           this._spec.$emitEvent(DhtEvent.peerTimedOut(ref.peerAddress))

--- a/lib/n3h-mod-dht-fullsync/dht-fullsync.js
+++ b/lib/n3h-mod-dht-fullsync/dht-fullsync.js
@@ -378,7 +378,9 @@ class DhtBackendFullsync extends AsyncClass {
         // Remove peer from peerStore
         this.dropPeerLocal(ref.peerAddress)
         // Notify owner
-        this._iface.$emitEvent(DhtEvent.peerTimedOut(ref.peerAddress))
+        if (this._spec) {
+          this._spec.$emitEvent(DhtEvent.peerTimedOut(ref.peerAddress))
+        }
         return setImmediate(() => this._gossip())
       }
     }


### PR DESCRIPTION
This fixes several issues that all occur when a peer is lost and that were rendering the running instance broken through an unhandled exception and/or loosing all information about the peer so that reconnecting was not possible.

Mainly this line in `dht-fullsync.js` was a logical error I believe and gets removed here:
```js
// Remove peer from peerStore
this.dropPeerLocal(ref.peerAddress)
```
Peer store is holding the information about the peer such as the transport address and not dropping it results in `_ensureCIdForPeer()` being able to reconnect again.