### PR TITLE
Fix meta handling in hackmode

### DIFF
--- a/lib/hackmode/index.js
+++ b/lib/hackmode/index.js
@@ -354,8 +354,8 @@ class N3hHackMode extends N3hMode {
 
         // If the requester is us we need to send this result to core via the
         // IPC channel, if not we send it on to a remote node.
-        const local_address = this._p2p.getId()
-        if (mId == local_address) {
+        const localAddress = this._p2p.getId()
+        if (mId === localAddress) {
           message.method = message.type
           this._ipcSend('json', message)
         } else {

--- a/lib/hackmode/index.js
+++ b/lib/hackmode/index.js
@@ -339,7 +339,8 @@ class N3hHackMode extends N3hMode {
         if (mId === null) {
           return
         }
-        this._p2pSend(mId, {
+
+        const message = {
           type: 'fetchMetaResult',
           _id: data._id,
           dnaAddress: data.dnaAddress,
@@ -349,7 +350,18 @@ class N3hHackMode extends N3hMode {
           entryAddress: data.entryAddress,
           attribute: data.attribute,
           contentList: data.contentList
-        })
+        }
+
+        // If the requester is us we need to send this result to core via the
+        // IPC channel, if not we send it on to a remote node.
+        const local_address = this._p2p.getId()
+        if (mId == local_address) {
+          message.method = message.type
+          this._ipcSend('json', message)
+        } else {
+          this._p2pSend(mId, message)
+        }
+
         return
       case 'handleGetPublishingEntryListResult':
         // Note: data is EntryListData


### PR DESCRIPTION
I'm not sure when this regression was introduced but after updating my local n3h and the branches I was working on (mainly the IPv6 branch) to master, I stopped seeing core receiving `FetchMetaResult`s. I could verify that this is happening with vanilla n3h master and holochain-rust develop.

I found out that n3h was always trying to send that result to a remote node and never returning it back to core. This fixes that.