### PR TITLE
Graceful shutdown with Protocol::Shutdown

### DIFF
--- a/lib/exe.js
+++ b/lib/exe.js
@@ -151,13 +151,13 @@ async function main () {
   log.i('executing mode ' + mode)
   switch (mode) {
     case 'REAL':
-      n3hNode = await new N3hRealMode(workDir, rawConfigData)
+      n3hNode = await new N3hRealMode(workDir, rawConfigData, terminate)
       break
     case 'MOCK':
-      n3hNode = await new N3hMock(workDir, rawConfigData)
+      n3hNode = await new N3hMock(workDir, rawConfigData, terminate)
       break
     case 'HACK':
-      n3hNode = await new N3hHackMode(workDir, rawConfigData)
+      n3hNode = await new N3hHackMode(workDir, rawConfigData, terminate)
       break
     default:
       log.e('Mode disabled or unknown')

--- a/lib/hackmode/index.js
+++ b/lib/hackmode/index.js
@@ -39,8 +39,8 @@ const log = tweetlog('@hackmode@')
  * - `webproxy.wssRelayPeers` {array<uri>} - Cannot be paired with `wssAdvertise`. Uri array of relay peers to connect through. (currently you can only specify 1). Use this if behind a NAT, all messages will be routed through the peer specified here.
  */
 class N3hHackMode extends N3hMode {
-  async init (workDir, rawConfigData) {
-    await super.init(workDir, rawConfigData)
+  async init (workDir, rawConfigData, terminate) {
+    await super.init(workDir, rawConfigData, terminate)
 
     this._peerBook = {}
     this._requestBook = new Map()

--- a/lib/hackmode/realmode.js
+++ b/lib/hackmode/realmode.js
@@ -48,8 +48,8 @@ const { $sleep } = require('../n3h-common')
  * - `webproxy.wssRelayPeers` {array<uri>} - Cannot be paired with `wssAdvertise`. Uri array of relay peers to connect through. (currently you can only specify 1). Use this if behind a NAT, all messages will be routed through the peer specified here.
  */
 class N3hRealMode extends N3hMode {
-  async init (workDir, rawConfigData) {
-    await super.init(workDir, rawConfigData)
+  async init (workDir, rawConfigData, terminate) {
+    await super.init(workDir, rawConfigData, terminate)
 
     this._requestBook = new Map()
 
@@ -90,7 +90,10 @@ class N3hRealMode extends N3hMode {
    * Convert my peerAddress into log friendly format
    */
   me () {
-    return this.nick(this._p2p.getId())
+    if (this._p2p) {
+      return this.nick(this._p2p.getId())
+    }
+    return '(xxxx)'
   }
 
   /**
@@ -668,7 +671,7 @@ class N3hRealMode extends N3hMode {
       case 'dataFetch':
         // Issued by dht._fetchDataLocal()
         // My dht asked me for all the data of an entry, give it a response
-        log.t(this.me() + ' dataFetch', e)
+        // log.t(this.me() + ' dataFetch', e)
         // Get entryAddress
         const entryAddress = e.dataAddress
         // log.e(this.me() + ' entryAddress', entryAddress)
@@ -699,7 +702,7 @@ class N3hRealMode extends N3hMode {
         if (!dhtData.dataFetchProviderAgentId) {
           log.e(this.me() + ' AgentId not found for DNA ' + dnaAddress + ' ; during handleDhtEvent(dataFetch)')
         }
-        log.t(this.me() + ' dataFetchResponse:', dhtData)
+        // log.t(this.me() + ' dataFetchResponse:', dhtData)
         dhtData = Buffer.from(JSON.stringify(dhtData), 'utf8').toString('base64')
         this._getDhtRef(dnaAddress).post(Dht.DhtEvent.dataFetchResponse(e.msgId, dhtData))
         break

--- a/lib/interface/connection-iface.js
+++ b/lib/interface/connection-iface.js
@@ -93,6 +93,9 @@ class Connection extends AsyncClass {
 
     this.$pushDestructor(async () => {
       if (this._backend && !this._backend.$isDestroying()) {
+        for (let id of this.keys()) {
+          await this.close(id)
+        }
         await this._backend.destroy()
       }
       this._backend = null

--- a/lib/interface/connection-iface.js
+++ b/lib/interface/connection-iface.js
@@ -93,9 +93,6 @@ class Connection extends AsyncClass {
 
     this.$pushDestructor(async () => {
       if (this._backend && !this._backend.$isDestroying()) {
-        for (let id of this.keys()) {
-          await this.close(id)
-        }
         await this._backend.destroy()
       }
       this._backend = null

--- a/lib/n3h-ipc/n3hMode.js
+++ b/lib/n3h-ipc/n3hMode.js
@@ -39,11 +39,13 @@ const log = tweetlog('*n3hMode*')
  * - `webproxy.wssRelayPeers` {array<uri>} - Cannot be paired with `wssAdvertise`. Uri array of relay peers to connect through. (currently you can only specify 1). Use this if behind a NAT, all messages will be routed through the peer specified here.
  */
 class N3hMode extends AsyncClass {
-  async init (workDir, rawConfigData) {
+  async init (workDir, rawConfigData, terminate) {
     await super.init()
 
     this._config = config(rawConfigData || {})
     log.i('@@ CONFIG @@', JSON.stringify(this._config, null, 2))
+
+    this._terminate = terminate || {}
 
     this._memory = {}
 
@@ -65,6 +67,11 @@ class N3hMode extends AsyncClass {
 
     this.$pushDestructor(async () => {
       if (this._ipc) {
+        this._ipcSend('terminated')
+        for (let id of this._ipc.keys()) {
+          log.t('TERMINATED - closing', id)
+          await this._ipc.close(id)
+        }
         await this._ipc.destroy()
       }
       this._ipc = null
@@ -125,6 +132,10 @@ class N3hMode extends AsyncClass {
         // for now just sending to everything
         this._ipc.send(Array.from(this._ipc.keys()), msg)
         break
+      case 'terminated':
+        let signal = msgpack.encode({ name: 'terminated', data: '' }).toString('base64')
+        this._ipc.send(Array.from(this._ipc.keys()), signal)
+        break
       default:
         throw new Error('unexpected ipc send type: ' + type)
     }
@@ -150,7 +161,11 @@ class N3hMode extends AsyncClass {
       case 'message':
         const dataPre = msgpack.decode(Buffer.from(ev.buffer, 'base64'))
         const name = dataPre.name.toString()
+        // log.t('Received from IPC: message:', name, dataPre)
         switch (name) {
+          case 'shutdown':
+            this._terminate()
+            break
           case 'json':
             const data = JSON.parse(dataPre.data.toString('utf8'))
             if (typeof data.method !== 'string') {

--- a/lib/n3h-ipc/n3hMode.js
+++ b/lib/n3h-ipc/n3hMode.js
@@ -45,7 +45,7 @@ class N3hMode extends AsyncClass {
     this._config = config(rawConfigData || {})
     log.i('@@ CONFIG @@', JSON.stringify(this._config, null, 2))
 
-    this._terminate = terminate || {}
+    this._terminate = terminate || (() => {})
 
     this._memory = {}
 
@@ -68,10 +68,6 @@ class N3hMode extends AsyncClass {
     this.$pushDestructor(async () => {
       if (this._ipc) {
         this._ipcSend('terminated')
-        for (let id of this._ipc.keys()) {
-          log.t('TERMINATED - closing', id)
-          await this._ipc.close(id)
-        }
         await this._ipc.destroy()
       }
       this._ipc = null

--- a/lib/n3h-ipc/n3hMode.js
+++ b/lib/n3h-ipc/n3hMode.js
@@ -68,6 +68,10 @@ class N3hMode extends AsyncClass {
     this.$pushDestructor(async () => {
       if (this._ipc) {
         this._ipcSend('terminated')
+        for (let id of this._ipc.keys()) {
+          log.t('TERMINATED - closing', id)
+          await this._ipc.close(id)
+        }
         await this._ipc.destroy()
       }
       this._ipc = null
@@ -161,7 +165,7 @@ class N3hMode extends AsyncClass {
       case 'message':
         const dataPre = msgpack.decode(Buffer.from(ev.buffer, 'base64'))
         const name = dataPre.name.toString()
-        // log.t('Received from IPC: message:', name, dataPre)
+        log.t('Received from IPC: message:', name, dataPre)
         switch (name) {
           case 'shutdown':
             this._terminate()

--- a/lib/n3h-mock/index.js
+++ b/lib/n3h-mock/index.js
@@ -11,8 +11,8 @@ class N3hMock extends N3hMode {
    * Network mock init.
    * Normally spawned by holochain_net where config is passed via environment variables
    */
-  async init (workDir, rawConfigData) {
-    await super.init(workDir, rawConfigData)
+  async init (workDir, rawConfigData, terminate) {
+    await super.init(workDir, rawConfigData, terminate)
 
     this._requestBook = {}
 


### PR DESCRIPTION
On receiving Shutdown from IPC, call exe.js `terminate()`.
In N3hMode's destructor: send Protocol::Terminated on all IPC connections.