### PR TITLE
mDNS on ZeroTier

### DIFF
--- a/lib/n3h-mod-discovery-mdns/discovery-mdns.js
+++ b/lib/n3h-mod-discovery-mdns/discovery-mdns.js
@@ -34,12 +34,14 @@ class DiscoveryMdns extends AsyncClass {
     this._id = initOptions.id
 
     this.discoveryInterface = this._iface = await new Discovery(this)
-
+    let re = new RegExp('.*://([^:^/]*)')
+    let hostname = initOptions.advertise.match(re)[1]
     this._mdns = mdns({
       multicast: true,
       port: this._port,
       loopback: true,
-      reuseAddr: true
+      reuseAddr: true,
+      interface: hostname
     })
 
     this._mdns.on('response', response => {

--- a/lib/n3h-mod-discovery-mdns/discovery-mdns.test.js
+++ b/lib/n3h-mod-discovery-mdns/discovery-mdns.test.js
@@ -13,7 +13,7 @@ describe('DiscoveryMdns Suite', () => {
     i1 = (await new DiscoveryMdns({
       id,
       port: 45454,
-      advertise: 'bla://111'
+      advertise: 'bla://0.0.0.0'
     })).discoveryInterface
     i1.found = new Set()
     i1.on('event', e => {
@@ -24,8 +24,8 @@ describe('DiscoveryMdns Suite', () => {
 
     i2 = (await new DiscoveryMdns({
       id,
-      port: 45454,
-      advertise: 'bla://222'
+      port: 45455,
+      advertise: 'bla://0.0.0.0'
     })).discoveryInterface
     i2.found = new Set()
     i2.on('event', e => {
@@ -44,10 +44,8 @@ describe('DiscoveryMdns Suite', () => {
     const start = Date.now()
     while (Date.now() - start < 6000) {
       if (
-        i1.found.has('bla://111') &&
-        i1.found.has('bla://222') &&
-        i2.found.has('bla://111') &&
-        i2.found.has('bla://222')
+        i1.found.has('bla://0.0.0.0') &&
+        i2.found.has('bla://0.0.0.0')
       ) {
         return
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -359,7 +359,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -505,7 +505,7 @@
     },
     "callsites": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
       "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
       "dev": true
     },
@@ -844,7 +844,7 @@
     },
     "debug-log": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/debug-log/-/debug-log-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/debug-log/-/debug-log-1.0.1.tgz",
       "integrity": "sha1-IwdjLUwEOCuN+KMvcLiVBG1SdF8=",
       "dev": true
     },
@@ -1194,7 +1194,7 @@
       "dependencies": {
         "doctrine": {
           "version": "1.5.0",
-          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+          "resolved": "http://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
           "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
           "dev": true,
           "requires": {
@@ -2507,13 +2507,13 @@
     },
     "minimist": {
       "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
       "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
       "dev": true
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
@@ -2522,7 +2522,7 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true
         }
@@ -2601,9 +2601,8 @@
       }
     },
     "multicast-dns": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-7.2.0.tgz",
-      "integrity": "sha512-Tu2QORGOFANB124NWQ/JTRhMf/ODouVLEuvu5Dz8YWEU55zQgRgFGnBHfIh5PbfNDAuaRl7yLB+pgWhSqVxi2Q==",
+      "version": "github:holochain/multicast-dns#05fbb6fe0e3902980d3a84f9c32c9d1b1d02f1b1",
+      "from": "github:holochain/multicast-dns",
       "requires": {
         "dns-packet": "^4.0.0",
         "thunky": "^1.0.2"
@@ -2628,7 +2627,7 @@
     },
     "ncp": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/ncp/-/ncp-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/ncp/-/ncp-1.0.1.tgz",
       "integrity": "sha1-0VNn5cuHQyuhF9K/gP30Wuz7QkY=",
       "dev": true
     },
@@ -3382,7 +3381,7 @@
     },
     "require-uncached": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+      "resolved": "http://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
       "dev": true,
       "requires": {
@@ -3730,7 +3729,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
@@ -3829,7 +3828,7 @@
     },
     "table": {
       "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/table/-/table-4.0.3.tgz",
+      "resolved": "http://registry.npmjs.org/table/-/table-4.0.3.tgz",
       "integrity": "sha512-S7rnFITmBH1EnyKcvxBh1LjYeQMmnZtCXSEbHcH6S0NoKit24ZuFO/T1vDcLdYsLQkM188PVVhQmzKIuThNkKg==",
       "dev": true,
       "requires": {
@@ -4004,7 +4003,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
@@ -4149,7 +4148,7 @@
       "dependencies": {
         "async": {
           "version": "0.9.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+          "resolved": "http://registry.npmjs.org/async/-/async-0.9.2.tgz",
           "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
           "dev": true
         }
@@ -4204,7 +4203,7 @@
     },
     "winston": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-2.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/winston/-/winston-2.1.1.tgz",
       "integrity": "sha1-PJNJ0ZYgf9G9/51LxD73JRDjoS4=",
       "dev": true,
       "requires": {
@@ -4219,7 +4218,7 @@
       "dependencies": {
         "async": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
+          "resolved": "http://registry.npmjs.org/async/-/async-1.0.0.tgz",
           "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k=",
           "dev": true
         },

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "express-ws": "^4.0.0",
     "helmet": "^3.15.0",
     "msgpack-lite": "^0.1.26",
-    "multicast-dns": "^7.2.0",
+    "multicast-dns": "github:holochain/multicast-dns",
     "node-forge": "^0.7.6",
     "sodium-native": "2.3.0",
     "ws": "^6.1.2"


### PR DESCRIPTION
# mDNS discovery with advertised hostname/address..
...so it uses right network when there are several interfaces, which is always the case when using ZeroTier.

The mDNS lib we are using can either figure out which interface to use, or we can set it.
If we don't set it it might not use the ZeroTier interface and we don't see other nodes.

These changes read the hostname/IP address out of the advertised URL via reg ex and provides it to the mdns constructor.

This *should* enable mDNS via ZeroTier, given that n3h is configured to use the ZeroTier interface/address for it's p2p binding.

Closes https://github.com/holochain/n3h/issues/100