### PR TITLE
some fixes to prevent n3h crashing during holochain-rust app-spec tests

### DIFF
--- a/lib/hackmode/p2p-backend-hackmode-peer.js
+++ b/lib/hackmode/p2p-backend-hackmode-peer.js
@@ -154,7 +154,7 @@ class P2pBackendHackmodePeer extends AsyncClass {
   /**
    */
   async transportConnect (remoteAdvertise) {
-    await this._ensureConnection(remoteAdvertise)
+    return this._ensureConnection(remoteAdvertise)
   }
 
   /**
@@ -163,6 +163,7 @@ class P2pBackendHackmodePeer extends AsyncClass {
   async close (peerAddress) {
     if (this._conByPeerAddress.has(peerAddress)) {
       const cId = this._conByPeerAddress.get(peerAddress)
+      this._conByPeerAddress.delete(peerAddress)
       await this._con.close(cId)
     }
   }
@@ -217,15 +218,16 @@ class P2pBackendHackmodePeer extends AsyncClass {
       throw new Error('data must be a Buffer')
     }
     // Connect to all provided peers
-    let cIds = await Promise.all(peerAddressList.map(
+    const results = await Promise.all(peerAddressList.map(
       a => this._ensureCIdForPeerAddress(a).catch(e => {
         if (!timeoutRegex.test(e)) {
           console.error('@@ fixme publish error catch @@', e)
         }
+        return null
       })))
 
     // Filter for valid cIds and exit if there are none
-    cIds = cIds.filter(cId => cId !== undefined)
+    let cIds = results.filter(r => r && r.cId).map(r => r.cId)
     if (cIds.length === 0) {
       // log.i('Skipping publish because no connections to peers')
       return
@@ -269,11 +271,17 @@ class P2pBackendHackmodePeer extends AsyncClass {
     }
     // short circuit if we already have a connection for this peer
     if (this._conByPeerAddress.has(remotePeerAddress)) {
-      return this._conByPeerAddress.get(remotePeerAddress)
+      return {
+        cId: this._conByPeerAddress.get(remotePeerAddress),
+        isNew: false
+      }
     }
     // short circuit if we are already TRYING to connect to this peer
     if (this._newConTrack.has(remotePeerAddress)) {
-      return this._newConTrack.get(remotePeerAddress)
+      return {
+        cId: (await this._newConTrack.get(remotePeerAddress)).cId,
+        isNew: false
+      }
     }
     // Try to connect
     const promise = this._newConTrack.track(remotePeerAddress)
@@ -298,7 +306,10 @@ class P2pBackendHackmodePeer extends AsyncClass {
 
     // Return connection for this Peer if exists
     if (this._conByPeerAddress.has(peerAddress)) {
-      return this._conByPeerAddress.get(peerAddress)
+      return {
+        cId: this._conByPeerAddress.get(peerAddress),
+        isNew: false
+      }
     }
     // Connect to the peer via DHT
     const peerInfo = await this._dht.fetchPeer(peerAddress)
@@ -438,7 +449,7 @@ class P2pBackendHackmodePeer extends AsyncClass {
     for (let [peerAddress, cId] of this._conByPeerAddress) {
       if (connectionId === cId) {
         log.t(this._me() + ' Removing connection to', this._nick(peerAddress))
-        this._conByPeerAddress.delete(peerAddress)
+        this.close(peerAddress)
       }
     }
   }
@@ -486,7 +497,10 @@ class P2pBackendHackmodePeer extends AsyncClass {
         log.t(this._me() + ' Adding connection', this._nick(remotePeerInfo.peerAddress))
         this._conByPeerAddress.set(remotePeerInfo.peerAddress, cId)
         this._con.setMeta(cId, remotePeerInfo)
-        this._newConTrack.resolve(remotePeerInfo.peerAddress, cId)
+        this._newConTrack.resolve(remotePeerInfo.peerAddress, {
+          cId,
+          isNew: true
+        })
         await this._dht.post(DhtEvent.peerHoldRequest(
           remotePeerInfo.peerAddress,
           remotePeerInfo.peerTransport,

--- a/lib/hackmode/realmode.js
+++ b/lib/hackmode/realmode.js
@@ -83,10 +83,12 @@ class N3hRealMode extends N3hMode {
             if (uri === this._p2p.getAdvertise()) {
               continue
             }
-            this._p2p.transportConnect(uri).then(() => {
-              log.t(this.me() + ' connected', uri)
+            this._p2p.transportConnect(uri).then(res => {
+              if (res.isNew) {
+                log.t(this.me() + ' connected from MDNS discovery', uri)
+              }
             }, (err) => {
-              log.e(this.me() + '.connect (' + uri + ') failed', err.toString())
+              log.e(this.me() + '.connect (' + uri + ') MDNS failed', err.toString())
             }).catch(e => {})
           }
         }
@@ -253,10 +255,12 @@ class N3hRealMode extends N3hMode {
       case 'connect':
         // Note: data.peerAddress must be an Advertise
         // Connect to Peer
-        this._p2p.transportConnect(data.peerAddress).then(() => {
-          log.t(this.me() + ' connected', data.peerAddress)
+        this._p2p.transportConnect(data.peerAddress).then(res => {
+          if (res.isNew) {
+            log.t(this.me() + ' connected from IPC request', data.peerAddress)
+          }
         }, (err) => {
-          log.e(this.me() + '.connect (' + data.peerAddress + ') failed', err.toString())
+          log.e(this.me() + '.connect (' + data.peerAddress + ') IPC failed', err.toString())
         })
         return
       case 'trackDna':
@@ -1026,9 +1030,15 @@ class N3hRealMode extends N3hMode {
   /**
    * @private
    */
-  _untrack (dnaAddress, agentId) {
+  async _untrack (dnaAddress, agentId) {
     log.t(this.me() + ' _untrack() for "' + agentId + '" for DNA "' + dnaAddress + '"')
     this._removeTrack(agentId, dnaAddress)
+    const chainId = this._intoChainId(dnaAddress, agentId)
+    if (chainId in this._dhtPerChain) {
+      let dht = this._dhtPerChain[chainId]
+      delete this._dhtPerChain[chainId]
+      await dht.destroy()
+    }
   }
 
   /**

--- a/lib/n3h-mod-connection-wss/wss-connection.js
+++ b/lib/n3h-mod-connection-wss/wss-connection.js
@@ -227,7 +227,7 @@ class ConnectionBackendWss extends AsyncClass {
     }
 
     if (!this._cons.has(id)) {
-      throw new Error('unknown connection id: ' + id)
+      return
     }
     const ws = this._cons.get(id)
     ws.close(1000)

--- a/lib/n3h-mod-dht-fullsync/dht-fullsync2.js
+++ b/lib/n3h-mod-dht-fullsync/dht-fullsync2.js
@@ -19,6 +19,8 @@ function getHash (str) {
   return hasher.digest().toString('base64')
 }
 
+let __gcount = 0 // eslint-disable-line no-unused-vars
+
 /**
  */
 class DhtFullSync2 extends AsyncClass {
@@ -247,6 +249,7 @@ class DhtFullSync2 extends AsyncClass {
   /**
    */
   async _gossip () {
+    ++__gcount
     while (this._gossipLoopContinue) {
       // -- pick peers -- //
 
@@ -262,6 +265,7 @@ class DhtFullSync2 extends AsyncClass {
         }
 
         try {
+          // console.error('@@ __gcount', __gcount, this._thisPeer.peerAddress)
           await this._gossipToPeer(peer)
         } catch (e) { /* pass */ }
 
@@ -276,6 +280,7 @@ class DhtFullSync2 extends AsyncClass {
       // -- wait a bit before looping -- //
       await $sleep(200)
     }
+    --__gcount
 
     this._gossipLoopResolve()
   }
@@ -293,6 +298,7 @@ class DhtFullSync2 extends AsyncClass {
       await this._iface.$emitEvent(DhtEvent.peerHoldRequest(
         peer.peerAddress, peer.peerTransport, peer.peerData, peer.peerTs))
     }
+
     const wantData = []
     for (let [dataAddress, dataHashList] of data.data) {
       for (let dataHash of dataHashList) {
@@ -306,10 +312,13 @@ class DhtFullSync2 extends AsyncClass {
         break
       }
     }
-    this._iface.$emitEvent(DhtEvent.gossipTo([fromPeerAddress],
-      Buffer.from(JSON.stringify({
-        type: 'wantData', dataAddressList: wantData
-      })).toString('base64')))
+
+    if (wantData.length > 0) {
+      this._iface.$emitEvent(DhtEvent.gossipTo([fromPeerAddress],
+        Buffer.from(JSON.stringify({
+          type: 'wantData', dataAddressList: wantData
+        })).toString('base64')))
+    }
   }
 
   /**

--- a/lib/n3h-mod-dht-fullsync/dht-fullsync2.js
+++ b/lib/n3h-mod-dht-fullsync/dht-fullsync2.js
@@ -19,7 +19,6 @@ function getHash (str) {
   return hasher.digest().toString('base64')
 }
 
-
 /**
  */
 class DhtFullSync2 extends AsyncClass {

--- a/lib/n3h-mod-dht-fullsync/dht-fullsync2.js
+++ b/lib/n3h-mod-dht-fullsync/dht-fullsync2.js
@@ -169,11 +169,23 @@ class DhtFullSync2 extends AsyncClass {
         break
       case 'wantData':
         const resp = {}
+        const wait = []
+
         for (let addr of res.dataAddressList) {
           if (this._dataMap.has(addr)) {
-            resp[addr] = await this.fetchDataLocal(addr)
+            wait.push((async () => {
+              try {
+                resp[addr] = await this.fetchDataLocal(addr)
+              } catch (e) {
+                // we were not able to fetch the data,
+                // just don't include it in the response.
+              }
+            })())
           }
         }
+
+        await Promise.all(wait)
+
         await this._iface.$emitEvent(DhtEvent.gossipTo([task.fromPeerAddress],
           Buffer.from(JSON.stringify({
             type: 'wantDataResp', data: resp

--- a/lib/n3h-mod-dht-fullsync/dht-fullsync2.js
+++ b/lib/n3h-mod-dht-fullsync/dht-fullsync2.js
@@ -19,7 +19,6 @@ function getHash (str) {
   return hasher.digest().toString('base64')
 }
 
-let __gcount = 0 // eslint-disable-line no-unused-vars
 
 /**
  */
@@ -261,7 +260,6 @@ class DhtFullSync2 extends AsyncClass {
   /**
    */
   async _gossip () {
-    ++__gcount
     while (this._gossipLoopContinue) {
       // -- pick peers -- //
 
@@ -277,7 +275,6 @@ class DhtFullSync2 extends AsyncClass {
         }
 
         try {
-          // console.error('@@ __gcount', __gcount, this._thisPeer.peerAddress)
           await this._gossipToPeer(peer)
         } catch (e) { /* pass */ }
 
@@ -292,7 +289,6 @@ class DhtFullSync2 extends AsyncClass {
       // -- wait a bit before looping -- //
       await $sleep(200)
     }
-    --__gcount
 
     this._gossipLoopResolve()
   }


### PR DESCRIPTION
It looks like the major part was the crazy proliferation of gossip for all the old tests.

Depends on https://github.com/holochain/holochain-rust/pull/1572 because we need the untrack request in order to stop gossiping on all the old tests.

Fixes:
- return info on _ensure requests indicating if a new connection was created (or if we re-used an existing one)
- only log connect when it's a new connection
- properly clean up connections when closed through some code paths
- don't send empty wantData gossip messages
- properly shutdown gossip loops when Untrack is called
- fix an unhandled rejection on a call to fetchDataLocal