### PR TITLE
limit debug snapshot output

### DIFF
--- a/lib/debug-snapshot/index.js
+++ b/lib/debug-snapshot/index.js
@@ -4,6 +4,7 @@ const fs = require('fs')
 
 class DebugSnapshotState {
   constructor (file) {
+    this._streamWriter = null
     this._db = new Sqlite(file)
 
     // make sure we use the fast disk write method
@@ -44,8 +45,13 @@ class DebugSnapshotState {
     }, 10000)
   }
 
+  setStreamWriter (streamWriter) {
+    this._streamWriter = streamWriter
+  }
+
   destroy () {
     clearInterval(this._checkpointTimer)
+    this._streamWriter = null
     this._checkpointTimer = null
 
     this._casInsert = null
@@ -59,30 +65,42 @@ class DebugSnapshotState {
     this._db = null
   }
 
+  dumpOne (header, footer, entry, streamWriter) {
+    streamWriter || (streamWriter = this._streamWriter)
+    if (!streamWriter) {
+      throw new Error('specify streamWriter `(x) => { console.log(x) }`')
+    }
+    for (let k in entry) {
+      if (k.startsWith('$cas$')) {
+        const casItem = this._casSelectOne.get([entry[k]])
+        if (casItem) {
+          entry[k] = casItem
+        } else {
+          entry[k] = '[not found] ' + entry[k]
+        }
+      }
+    }
+    streamWriter(header + '\n' + JSON.stringify(entry, null, 2) + '\n' + footer)
+  }
+
   dump (streamWriter) {
+    streamWriter || (streamWriter = this._streamWriter)
     if (!streamWriter) {
       throw new Error('specify streamWriter `(x) => { console.log(x) }`')
     }
 
-    streamWriter(this._header('BEGIN DEBUG SNAPSHOT DUMP'))
+    streamWriter(this._header('BEGIN N3H DEBUG SNAPSHOT DUMP'))
 
     for (let e of this._logSelectAll.iterate()) {
-      streamWriter(`-- ${e.type} - ${(new Date(e.epoch_ms)).toISOString()} --`)
-      const entry = JSON.parse(e.entry)
-      for (let k in entry) {
-        if (k.startsWith('$cas$')) {
-          const casItem = this._casSelectOne.get([entry[k]])
-          if (casItem) {
-            entry[k] = casItem
-          } else {
-            entry[k] = '[not found] ' + entry[k]
-          }
-        }
-      }
-      streamWriter(JSON.stringify(entry, null, 2))
+      this.dumpOne(
+        `-- ${e.type} - ${(new Date(e.epoch_ms)).toISOString()} --`,
+        '',
+        JSON.parse(e.entry),
+        streamWriter
+      )
     }
 
-    streamWriter(this._header('END DEBUG SNAPSHOT DUMP'))
+    streamWriter(this._header('END N3H DEBUG SNAPSHOT DUMP'))
   }
 
   // -- private -- //
@@ -100,8 +118,19 @@ class DebugSnapshotState {
       this._casInsert.run(hash, JSON.stringify(
         casMap[hash], null, 2))
     }
-    this._logInsert.run(Date.now(), logType, JSON.stringify(
+    const now = Date.now()
+    this._logInsert.run(now, logType, JSON.stringify(
       logEntry, null, 2))
+
+    if (this._streamWriter) {
+      this.dumpOne(
+        `------- BEGIN N3H DEBUG SNAPSHOT LOG GENERATED -------
+-- ${logType} - ${(new Date(now)).toISOString()} --`,
+        '------- END N3H DEBUG SNAPSHOT LOG GENERATED -------',
+        logEntry,
+        this._streamWriter
+      )
+    }
   }
 }
 

--- a/lib/exe.js
+++ b/lib/exe.js
@@ -101,6 +101,7 @@ async function main () {
   }
 
   log.i('config', rawConfigData)
+  getDebugSnapshot().setStreamWriter(x => { console.error(x) })
   getDebugSnapshot().insert({}, 'startup', { config: rawConfigData })
 
   let mode = 'REAL'
@@ -124,7 +125,7 @@ async function main () {
     }
     try {
       getDebugSnapshot().insert({}, 'terminate', null)
-      getDebugSnapshot().dump(x => { console.error(x) })
+      getDebugSnapshot().dump()
       getDebugSnapshot().destroy()
       if (n3hNode) {
         await n3hNode.destroy()

--- a/lib/hackmode/config.js
+++ b/lib/hackmode/config.js
@@ -5,7 +5,7 @@ module.exports = exports = config.createDefinition({
   debug: {
     snapshotDumpTimerMs: config.entry({
       type: 'number',
-      default: 10000
+      default: 0
     })
   },
   network: {

--- a/lib/n3h-ipc/n3hMode.js
+++ b/lib/n3h-ipc/n3hMode.js
@@ -53,7 +53,7 @@ class N3hMode extends AsyncClass {
       this._config.debug.snapshotDumpTimerMs > 0
     ) {
       this._snapshotDumpTimer = setInterval(() => {
-        getDebugSnapshot().dump(x => { console.error(x) })
+        getDebugSnapshot().dump()
       }, this._config.debug.snapshotDumpTimerMs)
     }
 


### PR DESCRIPTION
- print out snapshot logs as they are generated
- the full log will also be dumped on terminate
- default the periodic full dump to zero (i.e. don't start a full dump timer)